### PR TITLE
Http Cache multi-tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "ezsystems/ezplatform-http-cache",
+    "description": "HTTP cache handling for eZ Platform.",
+    "type": "ezplatform-bundle",
+    "license": "GPL-2.0",
+    "authors": [
+        {
+            "name": "eZ Systems",
+            "email": "dev-team@ez.no"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {
+        "ezsystems/ezpublish-kernel": "^6.7",
+        "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
+        "symfony/symfony": "^2.7 | ^3.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.7.0",
+        "matthiasnoback/symfony-dependency-injection-test": "0.*",
+        "phpspec/phpspec": "^3.2",
+        "memio/spec-gen": "^0.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "EzSystems\\PlatformHttpCacheBundle\\": "src",
+            "EzSystems\\PlatformHttpCacheBundle\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "branch-alias": "1.0.x-dev"
+    }
+}

--- a/docs/fos_http_cache.md
+++ b/docs/fos_http_cache.md
@@ -1,0 +1,86 @@
+# FOSHttpCacheBundle usage in eZ
+
+Introduced with eZ Publish 5.4, [FOSHttpCacheBundle][fos] is supported by eZ Platform, and covers the following
+features:
+
+* Tags purging/baning (since version 1.8)
+* Http cache purge/ban
+* User context hash
+
+## Http cache clear
+Varnish proxy client from FOSHttpCache lib is now used for clearing eZ Http cache, even when using Symfony HttpCache.
+It sends, for each cache tag that needs to be expired, a `PURGE` request with a `key` header to the registered purge servers.
+
+### Symfony reverse proxy
+Symfony reverse proxy (aka HttpCache) is supported out of the box, all you have to do is to activate it.
+
+### Varnish
+For cache clearing to work properly, you can use the VCL from the [ezplatform `doc/varnish` directory][varnish_doc].
+
+## User context hash
+[FOSHttpCacheBundle *User Context feature* is used][fos_user_context] is activated by default.
+
+As the response can vary on a request header, the base solution is to make the kernel do a sub-request in order to retrieve
+the context (the **user context hash**). Once the *user hash* has been retrieved, it is injected into the original request 
+as the `X-User-Hash` header, making it possible to *vary* the HTTP response on this header:
+
+> The name of the [user hash header is configurable in FOSHttpCacheBundle][fos_user_context]. 
+> By default eZ Publish sets it to `**X-User-Hash**`.
+
+```php
+<?php
+use Symfony\Component\HttpFoundation\Response;
+
+// ...
+
+// Inside a controller action
+$response = new Response();
+$response->setVary( 'X-User-Hash' );
+```
+
+This solution is [implemented in Symfony reverse proxy (aka *HttpCache*)][fos_symfony_cache] 
+and is also accessible to [dedicated reverse proxies like Varnish][fos_varnish_cache].
+ 
+
+### Workflow
+Please refer to [FOSHttpCacheBundle documentation on how user context feature works][fos_user_context#how].
+
+### User hash generation
+Please refer to [FOSHttpCacheBundle documentation on how user hashes are being generated][fos_user_context#hashes].
+
+eZ Platform already interferes in the hash generation process, by adding current user permissions and limitations.
+One can also interfere in this process by [implementing custom context provider(s)][fos_user_context#providers].
+
+
+### Varnish
+While the described behavior comes out of the box with Symfony reverse proxy, Varnish is also supported. The documented
+[eZ Platform VCL][_doc].
+
+### Default options for FOSHttpCacheBundle defined in eZ
+The following configuration is defined in eZ by default for FOSHttpCacheBundle.
+You may override these settings.
+
+```yaml
+fos_http_cache:
+    proxy_client:
+        # "varnish" is used, even when using Symfony HttpCache.
+        default: varnish
+        varnish:
+            # Means http_cache.purge_servers defined for current SiteAccess.
+            servers: [$http_cache.purge_servers$]
+            
+    user_context:
+        enabled: true
+        # User context hash is cached during 10min
+        hash_cache_ttl: 600
+        user_hash_header: X-User-Hash
+```
+
+[varnish_doc]: https://github.com/ezsystems/ezplatform/blob/master/doc/varnish
+[fos]: http://foshttpcachebundle.readthedocs.org/
+[fos_user_context]: http://foshttpcachebundle.readthedocs.org/en/latest/features/user-context.html
+[fos_user_context#how]: http://foshttpcachebundle.readthedocs.org/en/latest/features/user-context.html#how_it_works
+[fos_user_context#providers]: http://foshttpcachebundle.readthedocs.org/en/latest/features/user-context.html#custom-context-providers
+[fos_user_context_hashes]: http://foshttpcachebundle.readthedocs.org/en/latest/features/user-context.html#generating-hashes
+[fos_symfony_cache]: http://foshttpcachebundle.readthedocs.org/en/latest/features/symfony-http-cache.html
+[fos_varnish_cache]: http://foshttpcache.readthedocs.org/en/latest/varnish-configuration.html

--- a/docs/response_taggers.md
+++ b/docs/response_taggers.md
@@ -1,0 +1,34 @@
+# Response taggers API
+
+> added in ezpublish-kernel 6.8
+
+ResponseTaggers will take a `Response`, a `ResponseConfigurator` and any value object, and will add tags to the Response
+based on the value.
+
+## Example
+This will add the 'content-<contentId>`, 'location-<mainLocationId>` and `content-type-<contentTypeId>` tags to the
+Response:
+
+```php
+$contentInfoResponseTagger->tag($response, $configurator, $contentInfo);
+```
+
+## The ResponseConfigurator
+A `ResponseCacheConfigurator` configures an HTTP Response object: make the response public, add tags, set the shared max
+age... It is provided to `ResponseTaggers` who use it to add the tags to the Response.
+
+The `ConfigurableResponseCacheConfigurator` (`ezplatform.view_cache.response_configurator`) will follow the `view_cache`
+configuration, and only enable cache if it is enabled in the configuration.
+
+## Delegator and Value Taggers
+Even though they share the same API, ResponseTaggers are of two types, reflected by their namespace: Delegator and Value.
+
+Delegator Taggers will extract another value, or several, from the given value, and pass it on to another tagger. For
+instance, a `ContentView` is covered by both the `ContentValueViewTagger` and the `LocationValueViewTagger`. The first will
+extract the `Content` from the `ContentView`, and pass it to the `ContentInfoTagger`. The second will extract the `Location`,
+and pass it to the `LocationViewTagger`.
+
+## The Dispatcher Tagger
+While it is more efficient to use a known tagger directly, sometimes you don't know what object you want to tag with.
+The Dispatcher ResponseTagger will accept any value, and will pass it to every tagger registered with the service tag
+`ezplatform.http_response_tagger`.

--- a/features/view_cache_tags.feature
+++ b/features/view_cache_tags.feature
@@ -1,0 +1,21 @@
+Feature: HTTP cache tagging of views
+Background:
+    Given that view cache is enabled
+
+Scenario: Viewing a content item tags the Response
+  Given a Content item
+   When I view this Content item
+   Then the response is tagged with "content-<contentId>"
+    And the response is tagged with "location-<locationId>"
+    And the response is tagged with "content-type-<contentTypeId>"
+
+Scenario: Viewing a particular location of a content tags the Response with that location's ID
+  Given a Content item with a secondary Location
+   When I view the Content item from that location
+   Then the response is tagged with "location-<secondaryLocationId>"
+
+Scenario: Viewing a content item with a relation with the default field template tags the Response
+  Given a Content item with a filled relation field
+    And the default template is used to render relation fields
+   When I view this content item
+   Then the response is tagged with "relation-<relatedContentId>"

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,7 @@
+extensions:
+    Memio\SpecGen\MemioSpecGenExtension: ~
+
+suites:
+    http_cache:
+        namespace: EzSystems\PlatformHttpCacheBundle
+        psr4_prefix: EzSystems\PlatformHttpCacheBundle

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<phpunit
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  bootstrap="bootstrap.php"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  colors="true"
+  >
+  <php>
+    <ini name="error_reporting" value="-1" />
+  </php>
+    <suites>
+        <suite><directory>./Tests</directory></suite>
+    </suites>
+</phpunit>

--- a/spec/EventSubscriber/HttpCacheResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/HttpCacheResponseSubscriberSpec.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace spec\EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class HttpCacheResponseSubscriberSpec extends ObjectBehavior
+{
+    public function let(
+        FilterResponseEvent $event,
+        Request $request,
+        Response $response,
+        ParameterBag $requestAttributes,
+        ResponseCacheConfigurator $configurator,
+        ResponseTagger $dispatcherTagger
+    ) {
+        $request->attributes = $requestAttributes;
+        $event->getRequest()->willReturn($request);
+        $event->getResponse()->willReturn($response);
+
+        $this->beConstructedWith($configurator, $dispatcherTagger);
+    }
+
+    public function it_does_not_enable_cache_if_the_view_is_not_a_cachableview(
+        FilterResponseEvent $event,
+        ResponseCacheConfigurator $configurator,
+        ParameterBag $requestAttributes,
+        View $nonCachableView
+    ) {
+        $requestAttributes->get('view')->willReturn($nonCachableView);
+        $configurator->enableCache()->shouldNotBecalled();
+
+        $this->configureCache($event);
+    }
+
+    public function it_does_not_enable_cache_if_it_is_disabled_in_the_view(
+        FilterResponseEvent $event,
+        ResponseCacheConfigurator $configurator,
+        CachableView $view,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->get('view')->willReturn($view);
+        $view->isCacheEnabled()->willReturn(false);
+        $configurator->enableCache()->shouldNotBecalled();
+
+        $this->configureCache($event);
+    }
+
+    public function it_enables_cache(
+        FilterResponseEvent $event,
+        ResponseCacheConfigurator $configurator,
+        CachableView $view,
+        ParameterBag $requestAttributes,
+        ResponseTagger $dispatcherTagger
+    ) {
+        $requestAttributes->get('view')->willReturn($view);
+        $view->isCacheEnabled()->willReturn(true);
+
+        $this->configureCache($event);
+
+        $configurator->enableCache(Argument::type(Response::class))->shouldHaveBeenCalled();
+        $configurator->setSharedMaxAge(Argument::type(Response::class))->shouldHaveBeenCalled();
+        $dispatcherTagger->tag($configurator, Argument::type(Response::class), $view)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
+++ b/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseConfigurator;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
+{
+    public function let(Response $response, ResponseHeaderBag $headers)
+    {
+        $response->headers = $headers;
+        $this->beConstructedWith(true, true, 30);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ConfigurableResponseCacheConfigurator::class);
+    }
+
+    public function it_sets_cache_control_to_public_if_viewcache_is_enabled(Response $response)
+    {
+        $this->beConstructedWith(true, false, 0);
+        $this->enableCache($response);
+
+        $response->setPublic()->shouldHaveBeenCalled();
+    }
+
+    public function it_does_not_set_cache_control_if_viewcache_is_disabled(Response $response)
+    {
+        $this->beConstructedWith(false, false, 0);
+        $this->enableCache($response);
+
+        $response->setPublic()->shouldNotHaveBeenCalled();
+    }
+
+    public function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(Response $response)
+    {
+        $this->beConstructedWith(true, false, 30);
+        $this->setSharedMaxAge($response);
+
+        $response->setSharedMaxAge(30)->shouldNotHaveBeenCalled();
+    }
+
+    public function it_does_not_set_shared_maxage_if_it_is_already_set_in_the_response(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(true, true, 30);
+        $headers->hasCacheControlDirective('s-maxage')->willReturn(true);
+
+        $this->setSharedMaxAge($response);
+
+        $response->setSharedMaxAge($response, 30)->shouldNotHaveBeenCalled();
+    }
+
+    public function it_sets_shared_maxage(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(true, true, 30);
+        $headers->hasCacheControlDirective('s-maxage')->willReturn(false);
+
+        $this->setSharedMaxAge($response);
+
+        $response->setSharedMaxAge(30)->shouldHaveBeenCalled();
+    }
+
+    public function it_does_not_add_tags_if_viewcache_is_disabled(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(false, false, 0);
+        $this->addTags($response, ['foo-1', 'bar-2']);
+
+        $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();
+    }
+
+    public function it_adds_tags_to_the_xkey_header(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(false, false, 0);
+        $this->addTags($response, ['foo-1', 'bar-2']);
+
+        $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();
+    }
+}

--- a/spec/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\ContentValueViewTagger;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentValueViewTaggerSpec extends ObjectBehavior
+{
+    public function let(ResponseTagger $contentInfoTagger)
+    {
+        $this->beConstructedWith($contentInfoTagger);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ContentValueViewTagger::class);
+    }
+
+    public function it_delegates_tagging_of_the_content_info(
+        ResponseTagger $contentInfoTagger,
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        ContentValueView $view
+    ) {
+        $contentInfo = new ContentInfo();
+        $content = new Content(['versionInfo' => new VersionInfo(['contentInfo' => $contentInfo])]);
+        $view->getContent()->willReturn($content);
+
+        $this->tag($configurator, $response, $view);
+
+        $contentInfoTagger->tag($configurator, $response, $contentInfo)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/ResponseTagger/Delegator/DispatcherTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/DispatcherTaggerSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\DispatcherTagger;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class DispatcherTaggerSpec extends ObjectBehavior
+{
+    public function let(ResponseTagger $taggerOne, ResponseTagger $taggerTwo)
+    {
+        $this->beConstructedWith([$taggerOne, $taggerTwo]);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(DispatcherTagger::class);
+    }
+
+    public function it_calls_tag_on_every_tagger(
+        ResponseTagger $taggerOne,
+        ResponseTagger $taggerTwo,
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        ValueObject $value
+    ) {
+        $this->tag($configurator, $response, $value);
+
+        $taggerOne->tag($configurator, $response, $value)->shouldHaveBeenCalled();
+        $taggerTwo->tag($configurator, $response, $value)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/ResponseTagger/Delegator/LocationValueViewTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/LocationValueViewTaggerSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\LocationValueViewTagger;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\LocationValueView;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationValueViewTaggerSpec extends ObjectBehavior
+{
+    public function let(ResponseTagger $locationTagger)
+    {
+        $this->beConstructedWith($locationTagger);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(LocationValueViewTagger::class);
+    }
+
+    public function it_delegates_tagging_of_the_location(
+        ResponseTagger $locationTagger,
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        LocationValueView $view
+    ) {
+        $location = new Location();
+        $view->getLocation()->willReturn($location);
+        $this->tag($configurator, $response, $view);
+
+        $locationTagger->tag($configurator, $response, $location)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
+++ b/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentInfoTaggerSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ContentInfoTagger::class);
+    }
+
+    public function it_ignores_non_content_info(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $this->tag($configurator, $response, null);
+
+        $configurator->addTags()->shouldNotHaveBeenCalled();
+    }
+
+    public function it_tags_with_content_and_content_type_id(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new ContentInfo(['id' => 123, 'contentTypeId' => 987]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['content-123', 'content-type-987'])->shouldHaveBeenCalled();
+    }
+
+    public function it_tags_with_location_id_if_one_is_set(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new ContentInfo(['mainLocationId' => 456]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['location-456'])->shouldHaveBeenCalled();
+    }
+}

--- a/spec/ResponseTagger/Value/LocationTaggerSpec.php
+++ b/spec/ResponseTagger/Value/LocationTaggerSpec.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationTaggerSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(LocationTagger::class);
+    }
+
+    public function it_ignores_non_location(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $this->tag($configurator, $response, null);
+
+        $configurator->addTags($response, Argument::any())->shouldNotHaveBeenCalled();
+    }
+
+    public function it_tags_with_location_id_if_not_main_location(
+        ResponseCacheConfigurator $configurator,
+        Response $response
+    ) {
+        $value = new Location(['id' => 123, 'contentInfo' => new ContentInfo(['mainLocationId' => 321])]);
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['location-123'])->shouldHaveBeenCalled();
+    }
+
+    public function it_tags_with_parent_location_id(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new Location(['parentLocationId' => 123, 'contentInfo' => new ContentInfo()]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['parent-123'])->shouldHaveBeenCalled();
+    }
+
+    public function it_tags_with_path_items(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new Location(['pathString' => '/1/2/123', 'contentInfo' => new ContentInfo()]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['path-1', 'path-2', 'path-123'])->shouldHaveBeenCalled();
+    }
+}

--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ *
+ */
+class KernelPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        // slots
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if ($this->isSignalSlot($id) ||
+                $this->isSmartCacheListener($id) ||
+                $this->isCacheTagListener($id)
+            ) {
+                $container->removeDefinition($id);
+            }
+        }
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return bool
+     */
+    protected function isSignalSlot($id)
+    {
+        return strpos($id, 'ezpublish.http_cache.signalslot.') === 0;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return bool
+     */
+    protected function isSmartCacheListener($id)
+    {
+        return preg_match('/ezpublish.cache_clear.content.[a-z_]]_listener/', $id);
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return bool
+     */
+    protected function isCacheTagListener($id)
+    {
+        return $id === 'ezpublish.view.cache_response_listener';
+    }
+}

--- a/src/DependencyInjection/Compiler/ResponseTaggersPass.php
+++ b/src/DependencyInjection/Compiler/ResponseTaggersPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Processes services tagged as ezplatform.cache_response_tagger, and registers them with the dispatcher.
+ */
+class ResponseTaggersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezplatform.view_cache.response_tagger.dispatcher')) {
+            return;
+        }
+
+        $taggers = [];
+
+        $taggedServiceIds = $container->findTaggedServiceIds('ezplatform.cache_response_tagger');
+        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+            $taggers[] = new Reference($taggedServiceId);
+        }
+
+        $dispatcher = $container->getDefinition('ezplatform.view_cache.response_tagger.dispatcher');
+        $dispatcher->replaceArgument(0, $taggers);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files.
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('ez_systems_platform_http_cache');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
@@ -17,6 +17,7 @@ class EzSystemsPlatformHttpCacheExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('default_settings.yml');
         $loader->load('services.yml');
+        $loader->load('slot.yml');
         $loader->load('view_cache.yml');
     }
 }

--- a/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
@@ -15,6 +15,8 @@ class EzSystemsPlatformHttpCacheExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('default_settings.yml');
+        $loader->load('services.yml');
         $loader->load('view_cache.yml');
     }
 }

--- a/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
@@ -15,5 +15,6 @@ class EzSystemsPlatformHttpCacheExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('view_cache.yml');
     }
 }

--- a/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+class EzSystemsPlatformHttpCacheExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+    }
+}

--- a/src/EventSubscriber/HttpCacheResponseSubscriber.php
+++ b/src/EventSubscriber/HttpCacheResponseSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Configures the Response HTTP cache properties.
+ */
+class HttpCacheResponseSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    private $dispatcherTagger;
+
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator
+     */
+    private $responseConfigurator;
+
+    public function __construct(ResponseCacheConfigurator $responseConfigurator, ResponseTagger $dispatcherTagger)
+    {
+        $this->responseConfigurator = $responseConfigurator;
+        $this->dispatcherTagger = $dispatcherTagger;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => 'configureCache'];
+    }
+
+    public function configureCache(FilterResponseEvent $event)
+    {
+        $view = $event->getRequest()->attributes->get('view');
+        if (!$view instanceof CachableView || !$view->isCacheEnabled()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $this->responseConfigurator->enableCache($response);
+        $this->responseConfigurator->setSharedMaxAge($response);
+        $this->dispatcherTagger->tag($this->responseConfigurator, $response, $view);
+    }
+}

--- a/src/EzSystemsPlatformHttpCacheBundle.php
+++ b/src/EzSystemsPlatformHttpCacheBundle.php
@@ -3,6 +3,7 @@
 namespace EzSystems\PlatformHttpCacheBundle;
 
 use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\ResponseTaggersPass;
+use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\KernelPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -13,5 +14,6 @@ class EzSystemsPlatformHttpCacheBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ResponseTaggersPass());
+        $container->addCompilerPass(new KernelPass());
     }
 }

--- a/src/EzSystemsPlatformHttpCacheBundle.php
+++ b/src/EzSystemsPlatformHttpCacheBundle.php
@@ -2,8 +2,16 @@
 
 namespace EzSystems\PlatformHttpCacheBundle;
 
+use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\ResponseTaggersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsPlatformHttpCacheBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ResponseTaggersPass());
+    }
 }

--- a/src/EzSystemsPlatformHttpCacheBundle.php
+++ b/src/EzSystemsPlatformHttpCacheBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class EzSystemsPlatformHttpCacheBundle extends Bundle
+{
+}

--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * File containing the TagAwareStore class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Proxy;
+
+use EzSystems\PlatformHttpCacheBundle\RequestAwarePurger;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * TagAwareStore implements all the logic for storing cache metadata regarding tags (locations, content type, ..).
+ */
+class TagAwareStore extends Store implements RequestAwarePurger
+{
+    const TAG_CACHE_DIR = 'ez';
+
+    /**
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    private $fs;
+
+    /**
+     * Injects a Filesystem instance
+     * For unit tests only.
+     *
+     * @internal
+     *
+     * @param \Symfony\Component\Filesystem\Filesystem $fs
+     */
+    public function setFilesystem(Filesystem $fs)
+    {
+        $this->fs = $fs;
+    }
+
+    /**
+     * @return \Symfony\Component\Filesystem\Filesystem
+     */
+    private function getFilesystem()
+    {
+        if (!isset($this->fs)) {
+            $this->fs = new Filesystem();
+        }
+
+        return $this->fs;
+    }
+
+    /**
+     * Writes a cache entry to the store for the given Request and Response.
+     *
+     * Existing entries are read and any that match the response are removed. This
+     * method calls write with the new list of cache entries.
+     *
+     * @param Request  $request  A Request instance
+     * @param Response $response A Response instance
+     *
+     * @return string The key under which the response is stored
+     *
+     * @throws \RuntimeException
+     */
+    public function write(Request $request, Response $response)
+    {
+        $key = parent::write($request, $response);
+
+        // Now save tags
+        $digest = $response->headers->get('X-Content-Digest');
+        $tags = $response->headers->get('xkey', null, false);
+
+        if ($response->headers->has('X-Location-Id')) {
+            $tags[] = 'location-' . $response->headers->get('X-Location-Id');
+        }
+
+        foreach (array_unique($tags) as $tag) {
+            if (false === $this->saveTag($tag, $digest)) {
+                throw new \RuntimeException('Unable to store the cache tag meta information.');
+            }
+        }
+
+        return $key;
+    }
+
+    /**
+     * Save digest for the given tag.
+     *
+     * @param string $tag    The tag key
+     * @param string $digest The digest hash to store representing the cache item.
+     *
+     * @return bool
+     */
+    private function saveTag($tag, $digest)
+    {
+        $path = $this->getTagPath($tag) . DIRECTORY_SEPARATOR . $digest;
+        if (!is_dir(dirname($path)) && false === @mkdir(dirname($path), 0777, true) && !is_dir(dirname($path))) {
+            return false;
+        }
+
+        $tmpFile = tempnam(dirname($path), basename($path));
+        if (false === $fp = @fopen($tmpFile, 'wb')) {
+            return false;
+        }
+        @fwrite($fp, $digest);
+        @fclose($fp);
+
+        if ($digest != file_get_contents($tmpFile)) {
+            return false;
+        }
+
+        if (false === @rename($tmpFile, $path)) {
+            return false;
+        }
+
+        @chmod($path, 0666 & ~umask());
+
+        return true;
+    }
+
+    /**
+     * Purges data from $request.
+     * If xkey or X-Location-Id (deprecated) header is present, the store will purge cache for given locationId or group of locationIds.
+     * If not, regular purge by URI will occur.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return bool True if purge was successful. False otherwise
+     */
+    public function purgeByRequest(Request $request)
+    {
+        if (!$request->headers->has('X-Location-Id') && !$request->headers->has('xkey')) {
+            return $this->purge($request->getUri());
+        }
+
+        // For BC with older purge code covering most use cases.
+        $locationId = $request->headers->get('X-Location-Id');
+        if ($locationId === '*' || $locationId === '.*') {
+            return $this->purgeAllContent();
+        }
+
+        if ($request->headers->has('xkey')) {
+            $tags = explode(' ', $request->headers->get('xkey'));
+        } elseif ($locationId[0] === '(' && substr($locationId, -1) === ')') {
+            // Deprecated: (123|456|789) => Purge for #123, #456 and #789 location IDs.
+            $tags = array_map(
+                function ($id) {return 'location-' . $id;},
+                explode('|', substr($locationId, 1, -1))
+            );
+        } else {
+            $tags = array('location-' . $locationId);
+        }
+
+        if (empty($tags)) {
+            return false;
+        }
+
+        foreach ($tags as $tag) {
+            $this->purgeByCacheTag($tag);
+        }
+
+        return true;
+    }
+
+    /**
+     * Purges cache for tag.
+     *
+     * @param string $tag
+     */
+    private function purgeByCacheTag($tag)
+    {
+        $cacheTagsCacheDir = $this->getTagPath($tag);
+        if (!file_exists($cacheTagsCacheDir) || !is_dir($cacheTagsCacheDir)) {
+            return;
+        }
+
+        $files = (new Finder())->files()->in($cacheTagsCacheDir);
+        foreach ($files as $file) {
+            // @todo Change to be able to reuse parent::invalidate() or parent::purge() ?
+            if ($digest = file_get_contents($file->getRealPath())) {
+                @unlink($this->getPath($digest));
+            }
+            @unlink($file);
+        }
+        // We let folder stay in case another process have just written new cache tags.
+    }
+
+    /**
+     * Returns cache dir for $tag.
+     *
+     * This method is public only for unit tests.
+     * Use it only if you know what you are doing.
+     *
+     * @internal
+     *
+     * @param int $tag
+     *
+     * @return string
+     */
+    public function getTagPath($tag = null)
+    {
+        $path = $this->root . DIRECTORY_SEPARATOR . static::TAG_CACHE_DIR;
+        if ($tag) {
+            // Flip the tag so we put id first so it gets sliced into folders.
+            // (otherwise we would easily reach inode limits on file system)
+            $tag = strrev($tag);
+            $path .= DIRECTORY_SEPARATOR . substr($tag, 0, 2) . DIRECTORY_SEPARATOR . substr($tag, 2, 2) . DIRECTORY_SEPARATOR . substr($tag, 4);
+        }
+
+        return $path;
+    }
+}

--- a/src/PurgeClient/FOSPurgeClient.php
+++ b/src/PurgeClient/FOSPurgeClient.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
+
+use FOS\HttpCacheBundle\CacheManager;
+
+/**
+ * Purge client based on FOSHttpCacheBundle.
+ *
+ * Only support BAN requests on purpose, to be able to invalidate cache for a
+ * collection of Location/Content objects.
+ */
+class FOSPurgeClient implements PurgeClientInterface
+{
+    /**
+     * @var \FOS\HttpCacheBundle\CacheManager
+     */
+    private $cacheManager;
+
+    public function __construct(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
+    public function __destruct()
+    {
+        $this->cacheManager->flush();
+    }
+
+    public function purge($tags)
+    {
+        if (empty($tags)) {
+            return;
+        }
+
+        // As key only support one tag being invalidated at a time, we loop.
+        // These will be queued by FOS\HttpCache\ProxyClient\Varnish and handled on kernel.terminate.
+        foreach (array_unique((array)$tags) as $tag) {
+            if (is_numeric($tag)) {
+                $tag = 'location-' . $tag;
+            }
+
+            $this->cacheManager->invalidatePath(
+                '/',
+                ['key' => $tag, 'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME']]
+            );
+        }
+    }
+
+    public function purgeAll()
+    {
+        $this->cacheManager->invalidate(['key' => '.*']);
+    }
+}

--- a/src/PurgeClient/LocalPurgeClient.php
+++ b/src/PurgeClient/LocalPurgeClient.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * File containing the LocalPurgeClient class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
+
+use EzSystems\PlatformHttpCacheBundle\RequestAwarePurger;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * LocalPurgeClient emulates an Http PURGE request to be received by the Proxy Tag cache store.
+ * Handy for single-serve using Symfony Proxy..
+ */
+class LocalPurgeClient implements PurgeClientInterface
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\RequestAwarePurger
+     */
+    protected $cacheStore;
+
+    public function __construct(RequestAwarePurger $cacheStore)
+    {
+        $this->cacheStore = $cacheStore;
+    }
+
+    public function purge($tags)
+    {
+        if (empty($tags)) {
+            return;
+        }
+
+        $tags = array_map(
+            function ($tag) {
+                return is_numeric($tag) ? 'location-' . $tag : $tag;
+            },
+            (array)$tags
+        );
+
+        $purgeRequest = Request::create('http://localhost/', 'PURGE');
+        $purgeRequest->headers->set('key', implode(' ', $tags));
+        $this->cacheStore->purgeByRequest($purgeRequest);
+    }
+
+    /**
+     * Can we find a way to NOT implement this method ?
+     * PurgeClientInterface is defined in eZ/Publish/Core/MVC/Symfony/Cache/Http, and purgeAll() is defined in it,
+     * but deprecated by the multi-tagging implementation.
+     *
+     * Could we add PurgeClientInterface to HttpCacheBundle, and remove purgeAll from this version ?
+     * How would this work with the current implementation ?
+     */
+    public function purgeAll()
+    {
+        $this->cacheStore->purgeAllContent();
+    }
+}

--- a/src/PurgeClient/PurgeClientInterface.php
+++ b/src/PurgeClient/PurgeClientInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * File containing the Cache PurgeClientInterface class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface as KernelPurgeClientInterface;
+
+/**
+ * KernelPurgeClientInterface is deprecated, and will be removed in a later version when compatibility with ezpublish-kernel 6.x is dropped.
+ */
+interface PurgeClientInterface extends KernelPurgeClientInterface
+{
+    /**
+     * Triggers the cache purge $locationIds.
+     *
+     * It's up to the implementor to decide whether to purge $locationIds right away or to delegate to a separate process.
+     *
+     * @param array $locationIds Cache resource(s) to purge (e.g. array of URI to purge in a reverse proxy)
+     */
+    public function purge($locationIds);
+}

--- a/src/PurgeClient/VarnishProxyClientFactory.php
+++ b/src/PurgeClient/VarnishProxyClientFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * File containing the VarnishProxyClientFactory class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\DynamicSettingParserInterface;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+/**
+ * Factory for Varnish proxy client.
+ */
+class VarnishProxyClientFactory
+{
+    /**
+     * @var ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var DynamicSettingParserInterface
+     */
+    private $dynamicSettingParser;
+
+    /**
+     * Configured class for Varnish proxy client service.
+     *
+     * @var string
+     */
+    private $proxyClientClass;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        DynamicSettingParserInterface $dynamicSettingParser,
+        $proxyClientClass
+    ) {
+        $this->configResolver = $configResolver;
+        $this->dynamicSettingParser = $dynamicSettingParser;
+        $this->proxyClientClass = $proxyClientClass;
+    }
+
+    /**
+     * Builds the proxy client, taking dynamically defined servers into account.
+     *
+     * @param array $servers
+     * @param string $baseUrl
+     *
+     * @return \FOS\HttpCache\ProxyClient\Varnish
+     */
+    public function buildProxyClient(array $servers, $baseUrl)
+    {
+        $allServers = array();
+        foreach ($servers as $server) {
+            if (!$this->dynamicSettingParser->isDynamicSetting($server)) {
+                $allServers[] = $server;
+                continue;
+            }
+
+            $settings = $this->dynamicSettingParser->parseDynamicSetting($server);
+            $configuredServers = $this->configResolver->getParameter(
+                $settings['param'],
+                $settings['namespace'],
+                $settings['scope']
+            );
+            $allServers = array_merge($allServers, (array)$configuredServers);
+        }
+
+        $class = $this->proxyClientClass;
+
+        return new $class($allServers, $baseUrl);
+    }
+}

--- a/src/RequestAwarePurger.php
+++ b/src/RequestAwarePurger.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * File containing the RequestAwarePurger interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Interface allowing implementor (cache Store) to purge Http cache from a request object.
+ */
+interface RequestAwarePurger
+{
+    /**
+     * Purges data from $request.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return bool True if purge was successful. False otherwise
+     */
+    public function purgeByRequest(Request $request);
+}

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -1,0 +1,2 @@
+parameters:
+    ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,23 @@
 services:
+    ezplatform.http_cache.cache_manager:
+        parent: fos_http_cache.cache_manager
+        class: FOS\HttpCacheBundle\CacheManager
+
+    ezplatform.http_cache.proxy_client.varnish.factory:
+        class: EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishProxyClientFactory
+        arguments: ["@ezpublish.config.resolver", "@ezpublish.config.dynamic_setting.parser", "%fos_http_cache.proxy_client.varnish.class%"]
+
+    ezplatform.http_cache.purge_client:
+        alias: ezplatform.http_cache.purge_client.local
+
+    ezplatform.http_cache.purge_client.fos:
+        class: EzSystems\PlatformHttpCacheBundle\PurgeClient\FOSPurgeClient
+        arguments: ["@ezpublish.http_cache.cache_manager"]
+
+    ezplatform.http_cache.purge_client.local:
+        class: EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient
+        arguments: ["@ezplatform.http_cache.store"]
+
     ezplatform.http_cache.store:
         alias: ezplatform.http_cache.tag_aware_store
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,0 +1,7 @@
+services:
+    ezplatform.http_cache.store:
+        alias: ezplatform.http_cache.tag_aware_store
+
+    ezplatform.http_cache.tag_aware_store:
+        class: EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore
+        arguments: ["%ezplatform.http_cache.store.root%"]

--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -1,0 +1,124 @@
+services:
+    # Content
+    ezplatform.http_cache.signalslot.abstract_content:
+        abstract: true
+        arguments: ["@ezplatform.http_cache.purge_client"]
+
+    ezplatform.http_cache.signalslot.assign_section:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\AssignSectionSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: SectionService\AssignSectionSignal }
+
+    ezplatform.http_cache.signalslot.copy_content:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\CopyContentSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\CopyContentSignal }
+
+    ezplatform.http_cache.signalslot.create_location:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\CreateLocationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\CreateLocationSignal }
+
+    ezplatform.http_cache.signalslot.delete_content:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteContentSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\DeleteContentSignal }
+
+    ezplatform.http_cache.signalslot.delete_location:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteLocationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\DeleteLocationSignal }
+
+    ezplatform.http_cache.signalslot.delete_version:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteVersionSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\DeleteVersionSignal }
+
+    ezplatform.http_cache.signalslot.hide_location:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\HideLocationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\HideLocationSignal }
+
+    ezplatform.http_cache.signalslot.move_subtree:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\MoveSubtreeSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\MoveSubtreeSignal }
+
+    ezplatform.http_cache.signalslot.publish_version:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\PublishVersionSlot
+        arguments: ["@ezplatform.http_cache.purge_client", "@ezpublish.spi.persistence.cache.locationHandler"]
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\PublishVersionSignal }
+
+    ezplatform.http_cache.signalslot.set_content_state:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\SetContentStateSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\SetContentStateSignal }
+
+    ezplatform.http_cache.signalslot.swap_location:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\SwapLocationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\SwapLocationSignal }
+
+    ezplatform.http_cache.signalslot.unhide_location:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\UnhideLocationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\UnhideLocationSignal }
+
+    ezplatform.http_cache.signalslot.update_location:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\UpdateLocationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\UpdateLocationSignal }
+
+    ezplatform.http_cache.signalslot.update_user:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\UpdateUserSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\UpdateUserSignal }
+
+    ezplatform.http_cache.signalslot.assign_user_to_user_group:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\AssignUserToUserGroupSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\AssignUserToUserGroupSignal }
+
+    ezplatform.http_cache.signalslot.unassign_user_from_user_group:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\UnassignUserFromUserGroupSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\UnAssignUserFromUserGroupSignal }
+
+    ezplatform.http_cache.signalslot.trash:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\TrashSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: TrashService\TrashSignal }
+
+    ezplatform.http_cache.signalslot.recover:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\RecoverSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: TrashService\RecoverSignal }
+
+    # Content Type
+    ezplatform.http_cache.signalslot.publish_content_type:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\PublishContentTypeSlot
+        arguments: ["@ezplatform.http_cache.purge_client"]
+        tags: [{ name: ezpublish.api.slot, signal: ContentTypeService\PublishContentTypeDraftSignal }]
+
+    ezplatform.http_cache.signalslot.delete_content_type:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteContentTypeSlot
+        arguments: ["@ezplatform.http_cache.purge_client"]
+        tags: [{ name: ezpublish.api.slot, signal: ContentTypeService\DeleteContentTypeSignal }]

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -1,0 +1,35 @@
+services:
+    ezplatform.view_cache.response_configurator:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator
+        arguments:
+            - '$content.view_cache$'
+            - '$content.ttl_cache$'
+            - '$content.default_ttl$'
+
+    ezplatform.view_cache.response_tagger.dispatcher:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\DispatcherTagger
+        # Taggers are added by a compiler pass
+        arguments:
+            - []
+
+    ezplatform.view_cache.response_tagger.content_value_view:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\ContentValueViewTagger
+        arguments: ['@ezplatform.view_cache.response_tagger.content_info']
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
+    ezplatform.view_cache.response_tagger.location_value_view:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\LocationValueViewTagger
+        arguments: ['@ezplatform.view_cache.response_tagger.location']
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
+    ezplatform.view_cache.response_tagger.content_info:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
+    ezplatform.view_cache.response_tagger.location:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger
+        tags:
+            - {name: ezplatform.cache_response_tagger}

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -1,4 +1,12 @@
 services:
+    ezplatform.view_cache.response_subscriber:
+        class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\HttpCacheResponseSubscriber
+        arguments:
+            - '@ezplatform.view_cache.response_configurator'
+            - '@ezplatform.view_cache.response_tagger.dispatcher'
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezplatform.view_cache.response_configurator:
         class: EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator
         arguments:

--- a/src/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
+++ b/src/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ResponseConfigurator;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A ResponseCacheConfigurator configurable by constructor arguments.
+ */
+class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
+{
+    /**
+     * True if view cache is enabled, false if it is not.
+     *
+     * @var bool
+     */
+    private $enableViewCache;
+
+    /**
+     * True if TTL cache is enabled, false if it is not.
+     * @var bool
+     */
+    private $enableTtlCache;
+
+    /**
+     * Default ttl for ttl cache.
+     *
+     * @var int
+     */
+    private $defaultTtl;
+
+    public function __construct($enableViewCache, $enableTtlCache, $defaultTtl)
+    {
+        $this->enableViewCache = $enableViewCache;
+        $this->enableTtlCache = $enableTtlCache;
+        $this->defaultTtl = $defaultTtl;
+    }
+
+    public function enableCache(Response $response)
+    {
+        if ($this->enableViewCache) {
+            $response->setPublic();
+        }
+
+        return $this;
+    }
+
+    public function setSharedMaxAge(Response $response)
+    {
+        if ($this->enableViewCache && $this->enableTtlCache && !$response->headers->hasCacheControlDirective('s-maxage')) {
+            $response->setSharedMaxAge($this->defaultTtl);
+        }
+
+        return $this;
+    }
+
+    public function addTags(Response $response, $tags)
+    {
+        if ($this->enableViewCache) {
+            $response->headers->set('xkey', $tags, false);
+        }
+
+        return $this;
+    }
+}

--- a/src/ResponseConfigurator/ResponseCacheConfigurator.php
+++ b/src/ResponseConfigurator/ResponseCacheConfigurator.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ResponseConfigurator;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Configures caching options of an HTTP Response.
+ */
+interface ResponseCacheConfigurator
+{
+    /**
+     * Enables cache on a Response.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return ResponseCacheConfigurator
+     */
+    public function enableCache(Response $response);
+
+    /**
+     * Sets the shared-max-age property of a Response if it is not already set.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return ResponseCacheConfigurator
+     */
+    public function setSharedMaxAge(Response $response);
+
+    /**
+     * Adds $tags to the response's cache tags header.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param string|array $tags Single tag, or array of tags
+     *
+     * @return ResponseCacheConfigurator
+     */
+    public function addTags(Response $response, $tags);
+}

--- a/src/ResponseTagger/Delegator/ContentValueViewTagger.php
+++ b/src/ResponseTagger/Delegator/ContentValueViewTagger.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentValueViewTagger implements ResponseTagger
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    private $contentInfoTagger;
+
+    public function __construct(ResponseTagger $contentInfoTagger)
+    {
+        $this->contentInfoTagger = $contentInfoTagger;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $view)
+    {
+        if (!$view instanceof ContentValueView || !($content = $view->getContent()) instanceof Content) {
+            return $this;
+        }
+
+        $contentInfo = $content->getVersionInfo()->getContentInfo();
+        $this->contentInfoTagger->tag($configurator, $response, $contentInfo);
+
+        return $this;
+    }
+}

--- a/src/ResponseTagger/Delegator/DispatcherTagger.php
+++ b/src/ResponseTagger/Delegator/DispatcherTagger.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Dispatches a value to all registered ResponseTaggers.
+ */
+class DispatcherTagger implements ResponseTagger
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    private $taggers = [];
+
+    public function __construct(array $taggers = [])
+    {
+        $this->taggers = $taggers;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value)
+    {
+        foreach ($this->taggers as $tagger) {
+            $tagger->tag($configurator, $response, $value);
+        }
+    }
+}

--- a/src/ResponseTagger/Delegator/LocationValueViewTagger.php
+++ b/src/ResponseTagger/Delegator/LocationValueViewTagger.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\LocationValueView;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationValueViewTagger implements ResponseTagger
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    private $locationTagger;
+
+    public function __construct(ResponseTagger $locationTagger)
+    {
+        $this->locationTagger = $locationTagger;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $view)
+    {
+        if (!$view instanceof LocationValueView || !($location = $view->getLocation()) instanceof Location) {
+            return $this;
+        }
+
+        $this->locationTagger->tag($configurator, $response, $location);
+
+        return $this;
+    }
+}

--- a/src/ResponseTagger/ResponseTagger.php
+++ b/src/ResponseTagger/ResponseTagger.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tags a Response based on data from a value.
+ */
+interface ResponseTagger
+{
+    /**
+     * Extracts tags from a value, and adds them using the Configurator.
+     *
+     * @param ResponseCacheConfigurator $configurator
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param mixed $value
+     *
+     * @return \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value);
+}

--- a/src/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/ResponseTagger/Value/ContentInfoTagger.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentInfoTagger implements ResponseTagger
+{
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value)
+    {
+        if (!$value instanceof ContentInfo) {
+            return $this;
+        }
+
+        $configurator->addTags(
+            $response,
+            ['content-' . $value->id, 'content-type-' . $value->contentTypeId]
+        );
+
+        if ($value->mainLocationId) {
+            $configurator->addTags($response, ['location-' . $value->mainLocationId]);
+        }
+    }
+}

--- a/src/ResponseTagger/Value/LocationTagger.php
+++ b/src/ResponseTagger/Value/LocationTagger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+
+class LocationTagger implements ResponseTagger
+{
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value)
+    {
+        if (!$value instanceof Location) {
+            return $this;
+        }
+
+        if ($value->id !== $value->contentInfo->mainLocationId) {
+            $configurator->addTags($response, ['location-' . $value->id]);
+        }
+
+        $configurator->addTags($response, ['parent-' . $value->parentLocationId]);
+        $configurator->addTags(
+            $response,
+            array_map(
+                function ($pathItem) {
+                    return 'path-' . $pathItem;
+                },
+                $value->path
+            )
+        );
+
+        return $this;
+    }
+}

--- a/src/SignalSlot/AbstractContentSlot.php
+++ b/src/SignalSlot/AbstractContentSlot.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * An abstract HTTP Cache purging Slot that purges cache for a Content.
+ *
+ * Will by default use the contentId property of the signal object, as it is the most common. Set generateTags()
+ * method in case of different signals or need to clear more then the defaults.
+ */
+abstract class AbstractContentSlot extends AbstractSlot
+{
+    /**
+     * Purges relevant HTTP cache for $signal.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->purgeClient->purge($this->generateTags($signal));
+    }
+
+    /**
+     * Default provides tags to clear content, relation, location, parent and sibling cache.
+     *
+     * Overload for tree operations where you also need to clear whole path.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return array
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = [];
+
+        if (isset($signal->contentId)) {
+            // self in all forms (also withouth locations)
+            $tags[] = 'content-' . $signal->contentId;
+            // reverse relations
+            $tags[] = 'relation-' . $signal->contentId;
+        }
+
+        if (isset($signal->locationId)) {
+            // self
+            $tags[] = 'location-' . $signal->locationId;
+            // direct children
+            $tags[] = 'parent-' . $signal->locationId;
+        }
+
+        if (isset($signal->parentLocationId)) {
+            // direct parent
+            $tags[] = 'location-' . $signal->parentLocationId;
+            // direct siblings
+            $tags[] = 'parent-' . $signal->parentLocationId;
+        }
+
+        return $tags;
+    }
+}

--- a/src/SignalSlot/AbstractSlot.php
+++ b/src/SignalSlot/AbstractSlot.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\SignalSlot\Slot;
+
+/**
+ * A abstract legacy slot covering common functions needed for legacy slots.
+ */
+abstract class AbstractSlot extends Slot
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface
+     */
+    protected $purgeClient;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface $purgeClient
+     */
+    public function __construct(PurgeClientInterface $purgeClient)
+    {
+        $this->purgeClient = $purgeClient;
+    }
+
+    public function receive(Signal $signal)
+    {
+        if (!$this->supports($signal)) {
+            return;
+        }
+
+        $this->purgeHttpCache($signal);
+    }
+
+    /**
+     * Checks if $signal is supported by this handler.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return bool
+     */
+    abstract protected function supports(Signal $signal);
+
+    /**
+     * Purges relevant HTTP cache for $signal.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    abstract protected function purgeHttpCache(Signal $signal);
+}

--- a/src/SignalSlot/AssignSectionSlot.php
+++ b/src/SignalSlot/AssignSectionSlot.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling AssignSectionSignal.
+ */
+class AssignSectionSlot extends AbstractContentSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\SectionService\AssignSectionSignal;
+    }
+}

--- a/src/SignalSlot/AssignUserToUserGroupSlot.php
+++ b/src/SignalSlot/AssignUserToUserGroupSlot.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling AssignUserToUserGroupSignal.
+ *
+ * @todo This might be incomplete: what about the user's own http cache (user hash) ?
+ */
+class AssignUserToUserGroupSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\UserService\AssignUserToUserGroupSignal;
+    }
+}

--- a/src/SignalSlot/CopyContentSlot.php
+++ b/src/SignalSlot/CopyContentSlot.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling CopyContentSignal.
+ */
+class CopyContentSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        return ['content-' . $signal->dstContentId, 'location-' . $signal->dstParentLocationId, 'path-' . $signal->dstParentLocationId];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\CopyContentSignal;
+    }
+}

--- a/src/SignalSlot/CreateLocationSlot.php
+++ b/src/SignalSlot/CreateLocationSlot.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling CreateLocationSignal.
+ */
+class CreateLocationSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\CreateLocationSignal;
+    }
+}

--- a/src/SignalSlot/DeleteContentSlot.php
+++ b/src/SignalSlot/DeleteContentSlot.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling DeleteContentSignal.
+ */
+class DeleteContentSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        foreach ($signal->affectedLocationIds as $locationId) {
+            $tags[] = 'path-' . $locationId;
+        }
+
+        return $tags;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\DeleteContentSignal;
+    }
+}

--- a/src/SignalSlot/DeleteContentTypeSlot.php
+++ b/src/SignalSlot/DeleteContentTypeSlot.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling DeleteContentTypeSlot.
+ */
+class DeleteContentTypeSlot extends AbstractSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentTypeService\DeleteContentTypeSignal;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeSignal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->purgeClient->purge(['content-type-' . $signal->contentTypeId]);
+    }
+}

--- a/src/SignalSlot/DeleteLocationSlot.php
+++ b/src/SignalSlot/DeleteLocationSlot.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling DeleteLocationSignal.
+ */
+class DeleteLocationSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'path-' . $signal->locationId;
+
+        return $tags;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\DeleteLocationSignal;
+    }
+}

--- a/src/SignalSlot/DeleteVersionSlot.php
+++ b/src/SignalSlot/DeleteVersionSlot.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling DeleteVersionSignal.
+ */
+class DeleteVersionSlot extends AbstractContentSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\DeleteVersionSignal;
+    }
+}

--- a/src/SignalSlot/HideLocationSlot.php
+++ b/src/SignalSlot/HideLocationSlot.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling HideLocationSignal.
+ */
+class HideLocationSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'path-' . $signal->locationId;
+
+        return $tags;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\HideLocationSignal;
+    }
+}

--- a/src/SignalSlot/HttpCacheSlot.php
+++ b/src/SignalSlot/HttpCacheSlot.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger;
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\SignalSlot\Slot;
+
+/**
+ * A abstract legacy slot covering common functions needed for legacy slots.
+ */
+abstract class HttpCacheSlot extends Slot
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger
+     */
+    protected $httpCacheClearer;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger $httpCacheClearer
+     */
+    public function __construct(GatewayCachePurger $httpCacheClearer)
+    {
+        $this->httpCacheClearer = $httpCacheClearer;
+    }
+
+    public function receive(Signal $signal)
+    {
+        if (!$this->supports($signal)) {
+            return;
+        }
+
+        $this->purgeHttpCache($signal);
+    }
+
+    /**
+     * Checks if $signal is supported by this handler.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return bool
+     */
+    abstract protected function supports(Signal $signal);
+
+    /**
+     * Purges the HTTP cache for $signal.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    abstract protected function purgeHttpCache(Signal $signal);
+}

--- a/src/SignalSlot/MoveSubtreeSlot.php
+++ b/src/SignalSlot/MoveSubtreeSlot.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling MoveSubtreeSignal.
+ */
+class MoveSubtreeSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        // @todo Missing info to clear sibling and parent cache of old parent!
+        return [
+            'path-' . $signal->locationId,
+            'location-' . $signal->newParentLocationId,
+            'parent-' . $signal->newParentLocationId,
+        ];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\MoveSubtreeSignal;
+    }
+}

--- a/src/SignalSlot/PublishContentTypeSlot.php
+++ b/src/SignalSlot/PublishContentTypeSlot.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling PublishContentTypeDraftSignal.
+ */
+class PublishContentTypeSlot extends AbstractSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentTypeService\PublishContentTypeDraftSignal;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\PublishContentTypeDraftSignal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->purgeClient->purge(['content-type-' . $signal->contentTypeDraftId]);
+    }
+}

--- a/src/SignalSlot/PublishVersionSlot.php
+++ b/src/SignalSlot/PublishVersionSlot.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler;
+
+/**
+ * A slot handling PublishVersionSignal.
+ */
+class PublishVersionSlot extends AbstractContentSlot
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    private $locationHandler;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface $purgeClient
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $spiLocationHandler
+     */
+    public function __construct(PurgeClientInterface $purgeClient, Handler $spiLocationHandler)
+    {
+        parent::__construct($purgeClient);
+        $this->locationHandler = $spiLocationHandler;
+    }
+
+    /**
+     * Default provides tags to clear content, relation, location, parent and sibling cache.
+     *
+     * Overload for tree operations where you also need to clear whole path.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal $signal
+     *
+     * @return array
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        foreach ($this->locationHandler->loadLocationsByContent($signal->contentId) as $location) {
+            // self
+            $tags[] = 'location-' . $location->id;
+            // children
+            $tags[] = 'parent-' . $location->id;
+            // parent
+            $tags[] = 'location-' . $location->parentId;
+            // siblings
+            $tags[] = 'parent-' . $location->parentId;
+        }
+
+        return $tags;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\PublishVersionSignal;
+    }
+}

--- a/src/SignalSlot/PurgeAllHttpCacheSlot.php
+++ b/src/SignalSlot/PurgeAllHttpCacheSlot.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\SignalSlot\Slot;
+
+/**
+ * An abstract slot for clearing all http caches.
+ *
+ * @deprecated By design clears all cache, will be removed in favour of more precise cache clearing.
+ */
+abstract class PurgeAllHttpCacheSlot extends HttpCacheSlot
+{
+    /**
+     * Purges all caches.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->httpCacheClearer->purgeAll();
+    }
+}

--- a/src/SignalSlot/PurgeForContentHttpCacheSlot.php
+++ b/src/SignalSlot/PurgeForContentHttpCacheSlot.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * An abstract HTTP Cache purging Slot that purges cache for a Content.
+ *
+ * Will by default use the contentId property of the signal object, as it is the most common. Override the
+ * extractContentId() method in your own signal to use a different property.
+ */
+abstract class PurgeForContentHttpCacheSlot extends HttpCacheSlot
+{
+    /**
+     * Purges all caches.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->httpCacheClearer->purgeForContent($this->extractContentId($signal), $this->extractLocationIds($signal));
+    }
+
+    /**
+     * Default implementation that returns the contentId property's value.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed Content ID
+     */
+    protected function extractContentId(Signal $signal)
+    {
+        return $signal->contentId;
+    }
+
+    /**
+     * Default implementation that returns the signal location property values.
+     *
+     * This is extracted and provided to purgeForContent in case content is trashed where affected location is no longer returned by API.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return array Location ID's
+     */
+    protected function extractLocationIds(Signal $signal)
+    {
+        $locationIds = [];
+        if (isset($signal->locationId)) {
+            $locationIds[] = $signal->locationId;
+        }
+
+        if (isset($signal->parentLocationId)) {
+            $locationIds[] = $signal->parentLocationId;
+        }
+
+        return $locationIds;
+    }
+}

--- a/src/SignalSlot/RecoverSlot.php
+++ b/src/SignalSlot/RecoverSlot.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling RecoverSignal.
+ */
+class RecoverSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'location-' . $signal->newParentLocationId;
+        $tags[] = 'parent-' . $signal->newParentLocationId;
+
+        return $tags;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\TrashService\RecoverSignal;
+    }
+}

--- a/src/SignalSlot/SetContentStateSlot.php
+++ b/src/SignalSlot/SetContentStateSlot.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling SetContentStateSignal.
+ */
+class SetContentStateSlot extends AbstractContentSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ObjectStateService\SetContentStateSignal;
+    }
+}

--- a/src/SignalSlot/SwapLocationSlot.php
+++ b/src/SignalSlot/SwapLocationSlot.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling SwapLocationSignal.
+ */
+class SwapLocationSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        return [
+            'location-' . $signal->location1Id,
+            'parent-' . $signal->location1Id,
+            'location-' . $signal->location2Id,
+            'parent-' . $signal->location2Id,
+        ];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\SwapLocationSignal;
+    }
+}

--- a/src/SignalSlot/TrashSlot.php
+++ b/src/SignalSlot/TrashSlot.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling TrashSignal.
+ */
+class TrashSlot extends AbstractContentSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\TrashService\TrashSignal;
+    }
+}

--- a/src/SignalSlot/UnassignUserFromUserGroupSlot.php
+++ b/src/SignalSlot/UnassignUserFromUserGroupSlot.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling UnAssignUserFromUserGroupSignal.
+ *
+ * @todo
+ * Is this right ? Does it require a full wipe of the cache ? Very unlikely.
+ * The User's Content's HTTP cache must be cleared, yes.
+ * And the user must be logged out, or its user hash cleared (not sure we can without clearing for all users)
+ */
+class UnassignUserFromUserGroupSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\UserService\UnAssignUserFromUserGroupSignal;
+    }
+}

--- a/src/SignalSlot/UnhideLocationSlot.php
+++ b/src/SignalSlot/UnhideLocationSlot.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling UnhideLocationSignal.
+ */
+class UnhideLocationSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'path-' . $signal->locationId;
+
+        return $tags;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\UnhideLocationSignal;
+    }
+}

--- a/src/SignalSlot/UpdateLocationSlot.php
+++ b/src/SignalSlot/UpdateLocationSlot.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling UpdateLocationSignal.
+ *
+ * @todo Signal missing info on parent location, which is relevant if priority of location was updated.
+ */
+class UpdateLocationSlot extends AbstractContentSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\UpdateLocationSignal;
+    }
+}

--- a/src/SignalSlot/UpdateUserSlot.php
+++ b/src/SignalSlot/UpdateUserSlot.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling UpdateUserSignal.
+ */
+class UpdateUserSlot extends AbstractContentSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        return ['content-' . $signal->userId];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\UserService\UpdateUserSignal;
+    }
+}

--- a/tests/Proxy/TagAwareStoreTest.php
+++ b/tests/Proxy/TagAwareStoreTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * File containing the TagAwareStoreTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\Proxy;
+
+use EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore;
+use Symfony\Component\HttpFoundation\Request;
+use PHPUnit_Framework_TestCase;
+
+class TagAwareStoreTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore
+     */
+    private $store;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->store = new TagAwareStore(__DIR__);
+    }
+
+    protected function tearDown()
+    {
+        array_map('unlink', glob(__DIR__ . '/*.purging'));
+        parent::tearDown();
+    }
+
+    public function testGetPath()
+    {
+        $path = $this->store->getTagPath('location-123') . DIRECTORY_SEPARATOR . 'en' . sha1('someContent');
+        $this->assertStringStartsWith(__DIR__ . DIRECTORY_SEPARATOR . 'ez' . DIRECTORY_SEPARATOR . '32' . DIRECTORY_SEPARATOR . '1-' . DIRECTORY_SEPARATOR . 'noitacol', $path);
+    }
+
+    public function testGetStalePath()
+    {
+        $this->markTestIncomplete('@todo Stale handling removed, needs adjustments once it is re added in new form');
+        // Generate the lock file to force using the stale cache dir
+        $locationId = 123;
+        $prefix = TagAwareStore::TAG_CACHE_DIR . DIRECTORY_SEPARATOR . $locationId;
+        $prefixStale = TagAwareStore::TAG_CACHE_DIR . DIRECTORY_SEPARATOR . $locationId;
+        $lockFile = $this->store->getLocationCacheLockName($locationId);
+        file_put_contents($lockFile, getmypid());
+
+        $path = $this->store->getPath($prefix . DIRECTORY_SEPARATOR . 'en' . sha1('someContent'));
+        $this->assertStringStartsWith(__DIR__ . DIRECTORY_SEPARATOR . $prefixStale, $path);
+        @unlink($lockFile);
+    }
+
+    public function testGetPathDeadProcess()
+    {
+        $this->markTestIncomplete('@todo Stale handling removed, needs adjustments once it is re added in new form');
+        if (!function_exists('posix_kill')) {
+            self::markTestSkipped('posix_kill() function is needed for this test');
+        }
+
+        $locationId = 123;
+        $prefix = TagAwareStore::TAG_CACHE_DIR . "/$locationId";
+        $lockFile = $this->store->getLocationCacheLockName($locationId);
+        file_put_contents($lockFile, '99999999999999999');
+
+        $path = $this->store->getPath("$prefix/en" . sha1('someContent'));
+        $this->assertStringStartsWith(__DIR__ . "/$prefix", $path);
+        $this->assertFalse(file_exists($lockFile));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getFilesystemMock()
+    {
+        return $this->getMock('Symfony\\Component\\Filesystem\\Filesystem');
+    }
+
+    public function testPurgeByRequestSingleLocation()
+    {
+        $this->markTestIncomplete('@todo needs adjustments for new impl on top of tags');
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationId = 123;
+        $locationCacheDir = $this->store->getTagPath('location-' . $locationId);
+        $staleCacheDir = str_replace(TagAwareStore::TAG_CACHE_DIR, TagAwareStore::TAG_CACHE_DIR, $locationCacheDir);
+
+        $fs
+            ->expects($this->any())
+            ->method('exists')
+            ->with($locationCacheDir)
+            ->will($this->returnValue(true));
+        $fs
+            ->expects($this->once())
+            ->method('mkdir')
+            ->with($staleCacheDir);
+        $fs
+            ->expects($this->once())
+            ->method('mirror')
+            ->with($locationCacheDir, $staleCacheDir);
+        $fs
+            ->expects($this->once())
+            ->method('remove')
+            ->with($locationCacheDir);
+
+        $request = Request::create('/', 'PURGE');
+        $request->headers->set('X-Location-Id', "$locationId");
+        $this->store->purgeByRequest($request);
+    }
+
+    public function testPurgeByRequestMultipleLocations()
+    {
+        $this->markTestIncomplete('@todo needs adjustments for new impl on top of tags');
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationIds = array(123, 456, 789);
+        $i = 0;
+        foreach ($locationIds as $locationId) {
+            $locationCacheDir = $this->store->getTagPath('location-' . $locationId);
+            $staleCacheDir = str_replace(TagAwareStore::TAG_CACHE_DIR, TagAwareStore::TAG_CACHE_DIR, $locationCacheDir);
+
+            $fs
+                ->expects($this->at($i++))
+                ->method('exists')
+                ->with($locationCacheDir)
+                ->will($this->returnValue(true));
+            $fs
+                ->expects($this->at($i++))
+                ->method('mkdir')
+                ->with($staleCacheDir);
+            $fs
+                ->expects($this->at($i++))
+                ->method('mirror')
+                ->with($locationCacheDir, $staleCacheDir);
+            $fs
+                ->expects($this->at($i++))
+                ->method('remove')
+                ->with($locationCacheDir);
+        }
+
+        $request = Request::create('/', 'BAN');
+        $request->headers->set('X-Location-Id', '(' . implode('|', $locationIds) . ')');
+        $this->store->purgeByRequest($request);
+    }
+}

--- a/tests/PurgeClient/FOSPurgeClientTest.php
+++ b/tests/PurgeClient/FOSPurgeClientTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * File containing the FOSPurgeClientTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient;
+
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\FOSPurgeClient;
+use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCacheBundle\CacheManager;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class FOSPurgeClientTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cacheManager;
+
+    /**
+     * @var FOSPurgeClient
+     */
+    private $purgeClient;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->cacheManager = $this->getMockBuilder(CacheManager::class)
+            ->setConstructorArgs(
+                array(
+                    $this->getMock(ProxyClientInterface::class),
+                    $this->getMock(
+                        UrlGeneratorInterface::class
+                    ),
+                )
+            )
+            ->getMock();
+        $this->purgeClient = new FOSPurgeClient($this->cacheManager);
+    }
+
+    public function testPurgeNoLocationIds()
+    {
+        $this->cacheManager
+            ->expects($this->never())
+            ->method('invalidate');
+        $this->purgeClient->purge(array());
+    }
+
+    public function testPurgeOneLocationId()
+    {
+        $locationId = 123;
+        $this->cacheManager
+            ->expects($this->once())
+            ->method('invalidatePath')
+            ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost']);
+
+        $this->purgeClient->purge($locationId);
+    }
+
+    /**
+     * @dataProvider purgeTestProvider
+     */
+    public function testPurge(array $locationIds)
+    {
+        foreach ($locationIds as $key => $locationId) {
+            $this->cacheManager
+                ->expects($this->at($key))
+                ->method('invalidatePath')
+                ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost']);
+        }
+
+        $this->purgeClient->purge($locationIds);
+    }
+
+    public function purgeTestProvider()
+    {
+        return array(
+            array(array(123)),
+            array(array(123, 456)),
+            array(array(123, 456, 789)),
+        );
+    }
+
+    public function testPurgeAll()
+    {
+        $this->cacheManager
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with(array('key' => '.*'));
+
+        $this->purgeClient->purgeAll();
+    }
+}

--- a/tests/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/PurgeClient/LocalPurgeClientTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * File containing the LocalPurgeClientTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient;
+
+/**
+ * Avoid test failure caused by time passing between generating expected & actual object.
+ *
+ * @return int
+ */
+function time()
+{
+    return 1417624982;
+}
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ContentPurger;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\RequestAwarePurger;
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class LocalPurgeClientTest extends PHPUnit_Framework_TestCase
+{
+    public function testPurge()
+    {
+        $locationIds = array(123, 456, 789);
+        $expectedBanRequest = Request::create('http://localhost', 'PURGE');
+        $expectedBanRequest->headers->set('key', 'location-123 location-456 location-789');
+
+        $cacheStore = $this->getMock(RequestAwarePurger::class);
+        $cacheStore
+            ->expects($this->once())
+            ->method('purgeByRequest')
+            ->with($this->equalTo($expectedBanRequest));
+
+        $purgeClient = new LocalPurgeClient($cacheStore);
+        $purgeClient->purge($locationIds);
+    }
+
+    public function testPurgeAll()
+    {
+        $cacheStore = $this->getMock(ContentPurger::class);
+        $cacheStore
+            ->expects($this->once())
+            ->method('purgeAllContent');
+
+        $purgeClient = new LocalPurgeClient($cacheStore);
+        $purgeClient->purgeAll();
+    }
+}

--- a/tests/SignalSlot/AbstractContentSlotTest.php
+++ b/tests/SignalSlot/AbstractContentSlotTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+abstract class AbstractContentSlotTest extends AbstractSlotTest
+{
+    protected $contentId = 42;
+    protected $locationId = null;
+    protected $parentLocationId = null;
+
+    /**
+     * @return array
+     */
+    public function generateTags()
+    {
+        $tags = [];
+        if ($this->contentId) {
+            $tags = ['content-' . $this->contentId, 'relation-' . $this->contentId];
+        }
+
+        if ($this->locationId) {
+            // self(s)
+            $tags[] = 'location-' . $this->locationId;
+            // children
+            $tags[] = 'parent-' . $this->locationId;
+        }
+
+        if ($this->parentLocationId) {
+            // parent(s)
+            $tags[] = 'location-' . $this->parentLocationId;
+            // siblings
+            $tags[] = 'parent-' . $this->parentLocationId;
+        }
+
+        return $tags;
+    }
+}

--- a/tests/SignalSlot/AbstractPurgeAllSlotTest.php
+++ b/tests/SignalSlot/AbstractPurgeAllSlotTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+abstract class AbstractPurgeAllSlotTest extends AbstractSlotTest implements PurgeAllExpectation
+{
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesAll($signal)
+    {
+        $this->cachePurgerMock->expects($this->once())->method('purgeAll');
+        $this->cachePurgerMock->expects($this->never())->method('purgeForContent');
+        parent::receive($signal);
+    }
+}

--- a/tests/SignalSlot/AbstractPurgeForContentSlotTest.php
+++ b/tests/SignalSlot/AbstractPurgeForContentSlotTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+abstract class AbstractPurgeForContentSlotTest extends AbstractSlotTest implements PurgeForContentExpectation
+{
+    protected static $contentId = 42;
+    protected static $locationIds = [];
+
+    /**
+     * @return mixed
+     */
+    public static function getContentId()
+    {
+        return static::$contentId;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function getLocationIds()
+    {
+        return static::$locationIds;
+    }
+
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesCacheForContent($signal)
+    {
+        $this->cachePurgerMock->expects($this->once())->method('purgeForContent')->with(self::getContentId(), self::getLocationIds());
+        $this->cachePurgerMock->expects($this->never())->method('purgeAll');
+        parent::receive($signal);
+    }
+}

--- a/tests/SignalSlot/AbstractSlotTest.php
+++ b/tests/SignalSlot/AbstractSlotTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
+use PHPUnit_Framework_TestCase;
+
+abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \EzSystems\PlatformHttpCacheBundle\SignalSlot\AbstractSlot */
+    protected $slot;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $purgeClientMock;
+
+    private $signal;
+
+    public function setUp()
+    {
+        $this->purgeClientMock = $this->getMock(PurgeClientInterface::class);
+        $this->slot = $this->createSlot();
+        $this->signal = $this->createSignal();
+    }
+
+    protected function createSlot()
+    {
+        $class = $this->getSlotClass();
+
+        return new $class($this->purgeClientMock);
+    }
+
+    /**
+     * @dataProvider getUnreceivedSignals
+     */
+    public function testDoesNotReceiveOtherSignals($signal)
+    {
+        $this->purgeClientMock->expects($this->never())->method('purge');
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+
+        $this->slot->receive($signal);
+    }
+
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesCacheForTags($signal)
+    {
+        $this->purgeClientMock->expects($this->once())->method('purge')->with($this->generateTags());
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+        $this->receive($signal);
+    }
+
+    /**
+     * @return array
+     */
+    abstract public function generateTags();
+
+    protected function receive($signal)
+    {
+        $this->slot->receive($signal);
+    }
+
+    public function getReceivedSignals()
+    {
+        return [[$this->createSignal()]];
+    }
+
+    /**
+     * All existing SignalSlots.
+     */
+    public function getUnreceivedSignals()
+    {
+        $arguments = [];
+
+        if (empty($arguments)) {
+            $signals = $this->getAllSignals();
+
+            foreach ($signals as $signalClass) {
+                if (in_array($signalClass, $this->getReceivedSignalClasses())) {
+                    continue;
+                }
+                $arguments[] = [new $signalClass()];
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @return array
+     */
+    private function getAllSignals()
+    {
+        return array(
+            'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateUrlAliasSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\RemoveAliasesSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateGlobalUrlAliasSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AddFieldDefinitionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CopyContentTypeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UnassignContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\PublishContentTypeDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AssignContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateFieldDefinitionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\RemoveFieldDefinitionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\EnableLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\UpdateLanguageNameSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\CreateLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\DisableLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\DeleteLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\MoveUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\DeleteUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\DeleteUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\DeleteSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\CreateSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\UpdateSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdatePolicySignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicySignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\EmptyTrashSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\DeleteTrashItemSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetPriorityOfObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\TranslateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\RemoveSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\CreateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\AddRelationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\AddTranslationInfoSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentMetadataSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\TranslateVersionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteRelationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal',
+        );
+    }
+}

--- a/tests/SignalSlot/AssignSectionSlotTest.php
+++ b/tests/SignalSlot/AssignSectionSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal;
+
+class AssignSectionSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new AssignSectionSignal(['contentId' => $this->contentId]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\AssignSectionSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal'];
+    }
+}

--- a/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
+++ b/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal;
+
+class AssignUserToUserGroupSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new AssignUserToUserGroupSignal(['userId' => $this->contentId, 'userGroupId' => 99]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId, 'content-99'];
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\AssignUserToUserGroupSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal'];
+    }
+}

--- a/tests/SignalSlot/CopyContentSlotTest.php
+++ b/tests/SignalSlot/CopyContentSlotTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal;
+
+class CopyContentSlotTest extends AbstractContentSlotTest
+{
+    protected $parentLocationId = 59;
+
+    public function createSignal()
+    {
+        return new CopyContentSignal(['dstContentId' => $this->contentId, 'dstParentLocationId' => $this->parentLocationId]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId, 'location-' . $this->parentLocationId, 'path-' . $this->parentLocationId];
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\CopyContentSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal'];
+    }
+}

--- a/tests/SignalSlot/CreateLocationSlotTest.php
+++ b/tests/SignalSlot/CreateLocationSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal;
+
+class CreateLocationSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new CreateLocationSignal(['contentId' => $this->contentId]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\CreateLocationSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal'];
+    }
+}

--- a/tests/SignalSlot/DeleteContentSlotTest.php
+++ b/tests/SignalSlot/DeleteContentSlotTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
+
+class DeleteContentSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new DeleteContentSignal(['contentId' => $this->contentId, 'affectedLocationIds' => [45, 55]]);
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-45';
+        $tags[] = 'path-55';
+
+        return $tags;
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteContentSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal'];
+    }
+}

--- a/tests/SignalSlot/DeleteLocationSlotTest.php
+++ b/tests/SignalSlot/DeleteLocationSlotTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal;
+
+class DeleteLocationSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
+
+    public function createSignal()
+    {
+        return new DeleteLocationSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+                'parentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-' . $this->locationId;
+
+        return $tags;
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteLocationSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal'];
+    }
+}

--- a/tests/SignalSlot/DeleteVersionSlotTest.php
+++ b/tests/SignalSlot/DeleteVersionSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal;
+
+class DeleteVersionSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new DeleteVersionSignal(['contentId' => $this->contentId]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteVersionSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal'];
+    }
+}

--- a/tests/SignalSlot/HideLocationSlotTest.php
+++ b/tests/SignalSlot/HideLocationSlotTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal;
+
+class HideLocationSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 99;
+
+    public function createSignal()
+    {
+        return new HideLocationSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-' . $this->locationId;
+
+        return $tags;
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\HideLocationSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal'];
+    }
+}

--- a/tests/SignalSlot/MoveSubtreeSlotTest.php
+++ b/tests/SignalSlot/MoveSubtreeSlotTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal;
+
+class MoveSubtreeSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
+
+    public function createSignal()
+    {
+        return new MoveSubtreeSignal(
+            [
+                'locationId' => $this->locationId,
+                'newParentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        return ['path-' . $this->locationId, 'location-' . $this->parentLocationId, 'parent-' . $this->parentLocationId];
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\MoveSubtreeSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal'];
+    }
+}

--- a/tests/SignalSlot/PublishVersionSlotTest.php
+++ b/tests/SignalSlot/PublishVersionSlotTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
+class PublishVersionSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 45;
+    protected $parentLocationId = 32;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    protected $spiLocationHandlerMock;
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\PublishVersionSlot';
+    }
+
+    public function createSignal()
+    {
+        return new PublishVersionSignal(['contentId' => $this->contentId]);
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal'];
+    }
+
+    protected function createSlot()
+    {
+        $class = $this->getSlotClass();
+        if ($this->spiLocationHandlerMock === null) {
+            $this->spiLocationHandlerMock = $this->getMock('eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        }
+
+        return new $class($this->purgeClientMock, $this->spiLocationHandlerMock);
+    }
+
+    /**
+     * @dataProvider getUnreceivedSignals
+     */
+    public function testDoesNotReceiveOtherSignals($signal)
+    {
+        $this->purgeClientMock->expects($this->never())->method('purge');
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+
+        $this->spiLocationHandlerMock->expects($this->never())->method('loadLocationsByContent');
+
+        $this->slot->receive($signal);
+    }
+
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesCacheForTags($signal)
+    {
+        $this->spiLocationHandlerMock
+            ->expects($this->once())
+            ->method('loadLocationsByContent')
+            ->with($this->contentId)
+            ->willReturn(
+                [
+                    new Location(['id' => $this->locationId, 'parentId' => $this->parentLocationId]),
+                ]
+            );
+
+        $this->purgeClientMock->expects($this->once())->method('purge')->with($this->generateTags());
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+        parent::receive($signal);
+    }
+}

--- a/tests/SignalSlot/PurgeAllExpectation.php
+++ b/tests/SignalSlot/PurgeAllExpectation.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+/**
+ * If a test implements this interface, it will be verified that purgeAll() is never called.
+ */
+interface PurgeAllExpectation
+{
+    public function testReceivePurgesAll($signal);
+}

--- a/tests/SignalSlot/PurgeForContentExpectation.php
+++ b/tests/SignalSlot/PurgeForContentExpectation.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+/**
+ * If a test implements this interface, it will be given the opportunity to add expectations to the purgeForContent
+ * invocation mocker used by the test, for instance to test which contentId was passed to purgeForContent.
+ */
+interface PurgeForContentExpectation
+{
+    public static function getContentId();
+
+    public function testReceivePurgesCacheForContent($signal);
+}

--- a/tests/SignalSlot/RecoverSlotTest.php
+++ b/tests/SignalSlot/RecoverSlotTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal;
+
+class RecoverSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 43;
+    protected $parentLocationId = 45;
+
+    public function createSignal()
+    {
+        return new RecoverSignal(
+            [
+                'contentId' => $this->contentId,
+                'newLocationId' => $this->locationId,
+                'newParentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        return [
+            'content-' . $this->contentId,
+            'relation-' . $this->contentId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
+        ];
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\RecoverSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal'];
+    }
+}

--- a/tests/SignalSlot/SetContentStateSlotTest.php
+++ b/tests/SignalSlot/SetContentStateSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal;
+
+class SetContentStateSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new SetContentStateSignal(['contentId' => $this->contentId]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\SetContentStateSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
+    }
+}

--- a/tests/SignalSlot/SlotTest.php
+++ b/tests/SignalSlot/SlotTest.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+interface SlotTest
+{
+    public static function createSignal();
+
+    public function getSlotClass();
+
+    public static function getReceivedSignalClasses();
+}

--- a/tests/SignalSlot/SwapLocationSlotTest.php
+++ b/tests/SignalSlot/SwapLocationSlotTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal;
+
+class SwapLocationSlotTest extends AbstractContentSlotTest
+{
+    public function setUp()
+    {
+        $this->markTestIncomplete('fixme');
+    }
+
+    public function createSignal()
+    {
+        return new SwapLocationSignal(['content1Id' => $this->contentId]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\SetContentStateSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
+    }
+}

--- a/tests/SignalSlot/TrashSlotTest.php
+++ b/tests/SignalSlot/TrashSlotTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal;
+
+class TrashSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
+
+    public function createSignal()
+    {
+        return new TrashSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+                'parentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\TrashSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal'];
+    }
+}

--- a/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
+++ b/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal;
+
+class UnassignUserFromUserGroupSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new UnAssignUserFromUserGroupSignal(['userId' => $this->contentId, 'userGroupId' => 99]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId, 'content-99'];
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\UnassignUserFromUserGroupSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal'];
+    }
+}

--- a/tests/SignalSlot/UnhideLocationSlotTest.php
+++ b/tests/SignalSlot/UnhideLocationSlotTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal;
+
+class UnhideLocationSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 99;
+
+    public function createSignal()
+    {
+        return new UnhideLocationSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-' . $this->locationId;
+
+        return $tags;
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\UnhideLocationSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal'];
+    }
+}

--- a/tests/SignalSlot/UpdateLocationSlotTest.php
+++ b/tests/SignalSlot/UpdateLocationSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal;
+
+class UpdateLocationSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new UpdateLocationSignal(['contentId' => $this->contentId]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\UpdateLocationSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal'];
+    }
+}

--- a/tests/SignalSlot/UpdateUserSlotTest.php
+++ b/tests/SignalSlot/UpdateUserSlotTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal;
+
+class UpdateUserSlotTest extends AbstractContentSlotTest
+{
+    public function createSignal()
+    {
+        return new UpdateUserSignal(['userId' => $this->contentId]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId];
+    }
+
+    public function getSlotClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\UpdateUserSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal'];
+    }
+}


### PR DESCRIPTION
> Implements [EZP-22401](http://jira.ez.no/browse/EZP-22401)

## Abstract
Moves all HTTP cache related elements from ezpublish-kernel to this package, and adds support for multi-tagging using the `xkey` header.

### TODO
- [x] Move the package to `ezsystems/ezplatform-http-cache`
- [ ] Test on 1.7 and 1.8.
- [x] ~~Create packagist.org package~~ (requires that master is merged)
- [x] ~~Open the ezplatform and ezpublish-kernel pull-requests~~ (not needed to merge this)
- [x] `.travis.yml` (follow-up)
- [x] ~~Move `UserContext` from ezpublish-kernel as well~~ (follow-up)
- [x] ~~Adapt the specifications files to the new structure~~~ (follow-up)
- [x] Describe