### PR TITLE
Fix kernel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,24 @@ Add the package to `app/AppKernel.php`, *before* the EzPublishCoreBundle declara
 The package will replace the services from the kernel, thus enabling the new features, such as multi-tagging.
 
 The application cache class needs to be customized. If you haven't changed the `AppCache` class, you can do so
-by setting the `SYMFONY_HTTP_CACHE_CLASS` environment variable:
+by setting the `SYMFONY_HTTP_CACHE_CLASS` environment variable for your PHP or web server user.
+If you use your own `AppCache` class, you will have to make it to extend from this class instead
+of from the CoreBundle's.
+
+For PHP's internal server:
 
     export SYMFONY_HTTP_CACHE_CLASS='EzSystems\PlatformHttpCacheBundle\AppCache'
 
-Do not forget to restart your web server.
+For Apache, with the default eZ Platform virtual host definition, uncomment the `SetEnv` lines for the two
+variables above in your virtualhost, and set the values accordingly:
 
-Alternatively, if you use your own `AppCache` class, you will have to make it to extend from this class instead.
+    SetEnv SYMFONY_HTTP_CACHE_CLASS='EzSystems\PlatformHttpCacheBundle\AppCache'
+
+For Nginx, set the variables using `fastcgi_param`:
+
+    fastcgi_param SYMFONY_HTTP_CACHE "1";
+    
+Do not forget to restart your web server.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Add the package to `app/AppKernel.php`, *before* the EzPublishCoreBundle declara
 
 The package will replace the services from the kernel, thus enabling the new features, such as multi-tagging.
 
+The application cache class needs to be customized. If you haven't changed the `AppCache` class, you can do so
+by setting the `SYMFONY_HTTP_CACHE_CLASS` environment variable:
+
+    export SYMFONY_HTTP_CACHE_CLASS='EzSystems\PlatformHttpCacheBundle\AppCache'
+
+Do not forget to restart your web server.
+
+Alternatively, if you use your own `AppCache` class, you will have to make it to extend from this class instead.
+
 ## Features
 
 ### `xkey` header on ContentView responses

--- a/spec/DependencyInjection/Compiler/KernelPassSpec.php
+++ b/spec/DependencyInjection/Compiler/KernelPassSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
+
+use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\KernelPass;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class KernelPassSpec extends ObjectBehavior
+{
+    function let(ContainerBuilder $container)
+    {
+        $container->getDefinitions()->willReturn([]);
+        $container->getAlias('ezpublish.http_cache.purge_client')->willReturn('some_random_id');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(KernelPass::class);
+    }
+
+    function it_disables_the_kernels_httpcache_slots(ContainerBuilder $container)
+    {
+        $container->getDefinitions()->willReturn([
+            'ezpublish.http_cache.witness_service' => new Definition(),
+            'ezpublish.http_cache.signalslot.some_slot' => new Definition(),
+            'ezpublish.http_cache.signalslot.some_other_slot' => new Definition(),
+            'witness_service' => new Definition(),
+        ]);
+        $container->removeDefinition('ezpublish.http_cache.signalslot.some_slot')->shouldBeCalled();
+        $container->removeDefinition('ezpublish.http_cache.signalslot.some_other_slot')->shouldBeCalled();
+
+        $this->process($container);
+    }
+
+    function it_disables_the_kernels_smartcache_event_listeners(ContainerBuilder $container)
+    {
+        $container->getDefinitions()->willReturn([
+            'ezpublish.cache_clear.content.some_listener' => new Definition(),
+            'witness_service' => new Definition(),
+        ]);
+        $container->removeDefinition('ezpublish.cache_clear.content.some_listener')->shouldBeCalled();
+
+        $this->process($container);
+    }
+
+    function it_disables_the_kernels_view_cache_response_listener(ContainerBuilder $container)
+    {
+        $container->getDefinitions()->willReturn([
+            'ezpublish.view.cache_response_listener' => new Definition(),
+            'witness_service' => new Definition(),
+        ]);
+        $container->removeDefinition('ezpublish.view.cache_response_listener')->shouldBeCalled();
+
+        $this->process($container);
+    }
+}

--- a/src/AppCache.php
+++ b/src/AppCache.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformHttpCacheBundle;
+
+use eZ\Bundle\EzPublishCoreBundle\HttpCache;
+use EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore;
+
+/**
+ * Custom AppCache.
+ *
+ * Enable by setting SYMFONY_HTTP_CACHE_CLASS to 'EzSystems\PlatformHttpCacheBundle\AppCache'
+ */
+class AppCache extends HttpCache
+{
+    protected function createStore()
+    {
+        return new TagAwareStore($this->cacheDir ?: $this->kernel->getCacheDir() . '/http_cache');
+    }
+}

--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -10,17 +10,17 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- *
+ * Disables some of the http-cache services declared by the kernel so that
+ * they can be replaced with this bundle's.
  */
 class KernelPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        // slots
         foreach ($container->getDefinitions() as $id => $definition) {
             if ($this->isSignalSlot($id) ||
                 $this->isSmartCacheListener($id) ||
-                $this->isCacheTagListener($id)
+                $this->isResponseCacheListener($id)
             ) {
                 $container->removeDefinition($id);
             }
@@ -44,7 +44,7 @@ class KernelPass implements CompilerPassInterface
      */
     protected function isSmartCacheListener($id)
     {
-        return preg_match('/ezpublish.cache_clear.content.[a-z_]]_listener/', $id);
+        return preg_match('/^ezpublish\.cache_clear\.content.[a-z_]+_listener/', $id);
     }
 
     /**
@@ -52,7 +52,7 @@ class KernelPass implements CompilerPassInterface
      *
      * @return bool
      */
-    protected function isCacheTagListener($id)
+    protected function isResponseCacheListener($id)
     {
         return $id === 'ezpublish.view.cache_response_listener';
     }

--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -123,7 +123,7 @@ class TagAwareStore extends Store implements RequestAwarePurger
 
     /**
      * Purges data from $request.
-     * If xkey or X-Location-Id (deprecated) header is present, the store will purge cache for given locationId or group of locationIds.
+     * If key or X-Location-Id (deprecated) header is present, the store will purge cache for given locationId or group of locationIds.
      * If not, regular purge by URI will occur.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
@@ -132,7 +132,7 @@ class TagAwareStore extends Store implements RequestAwarePurger
      */
     public function purgeByRequest(Request $request)
     {
-        if (!$request->headers->has('X-Location-Id') && !$request->headers->has('xkey')) {
+        if (!$request->headers->has('X-Location-Id') && !$request->headers->has('key')) {
             return $this->purge($request->getUri());
         }
 
@@ -142,8 +142,8 @@ class TagAwareStore extends Store implements RequestAwarePurger
             return $this->purgeAllContent();
         }
 
-        if ($request->headers->has('xkey')) {
-            $tags = explode(' ', $request->headers->get('xkey'));
+        if ($request->headers->has('key')) {
+            $tags = explode(' ', $request->headers->get('key'));
         } elseif ($locationId[0] === '(' && substr($locationId, -1) === ')') {
             // Deprecated: (123|456|789) => Purge for #123, #456 and #789 location IDs.
             $tags = array_map(


### PR DESCRIPTION
> [EZP-26982](https://jira.ez.no/browse/EZP-26982)

Fixes the integration of the package into ezpublish-kernel.

### Tasks
- [x] Make `AppCache` use `TagAwareStore`
- [x] Make sure that purge requests use the `key` header and not `xkey`
- [x] Write a specification for `KernelPass`