### PR TITLE
RFC: Added behat scenario for view cache

### DIFF
--- a/features/view_cache.feature
+++ b/features/view_cache.feature
@@ -1,0 +1,20 @@
+Feature: Views are cached by the reverse proxy, and purged by the repository.
+
+  Background:
+    Given that Symfony's reverse proxy is enabled
+      And View cache is enabled
+      And Purge type is set to local
+
+  Scenario: Content view is cached by the reverse proxy
+    Given that a content exists
+      And I am allowed to view it
+     When I view this Content
+     Then the response was cached
+     When I view this Content again
+     Then I get the cached response
+
+  Scenario: Publishing a new version of a Content expires its Content view cache
+    Given that a Content view is cached
+      And this Content gets updated
+      And I view this Content
+     Then I get the updated Content view


### PR DESCRIPTION
Aims at describing the behavior one expects from content views HTTP cache in eZ Platform.

## Feedback I'm looking for
- Actual target audience for these scenarii ("one" in the sentence above)
- Comments about the domain for this target audience being bad in sentences (too specific, not specific enough, etc)
- _Unknown_ missing scenarii :)

## Known missing scenarii
- [ ] siblings purge
- [ ] parent purge
- [ ] relations purge
- [ ] path purge