### PR TITLE
Added a ViewParameters ResponseTagger

### DIFF
--- a/spec/ResponseTagger/Delegator/ViewParametersTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/ViewParametersTaggerSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\ViewParametersTagger;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use stdClass;
+use Symfony\Component\HttpFoundation\Response;
+
+class ViewParametersTaggerSpec extends ObjectBehavior
+{
+    function let(ResponseTagger $dispatcherTagger)
+    {
+        $this->beConstructedWith($dispatcherTagger);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ViewParametersTagger::class);
+    }
+
+    function it_delegates_tagging_of_parameters_that_are_value_objects(
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        ResponseTagger $dispatcherTagger,
+        View $view,
+        ValueObject $someValueObject,
+        stdClass $someObject
+    ) {
+        $view->getParameters()->willReturn([
+            'value_object' => $someValueObject,
+            'object' => $someObject,
+            'string' => 'some_string',
+            'array' => ['a', 'b', 'c'],
+        ]);
+
+        $this->tag($configurator, $response, $view);
+
+        $dispatcherTagger->tag($configurator, $response, $someValueObject)->shouldHaveBeenCalled();
+        $dispatcherTagger->tag($configurator, $response, $someObject)->shouldNotHaveBeenCalled();
+        $dispatcherTagger->tag($configurator, $response, 'some_string')->shouldNotHaveBeenCalled();
+        $dispatcherTagger->tag($configurator, $response, ['a', 'b', 'c'])->shouldNotHaveBeenCalled();
+    }
+}

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -39,6 +39,12 @@ services:
         tags:
             - {name: ezplatform.cache_response_tagger}
 
+    ezplatform.view_cache.response_tagger.view_parameters:
+        class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\ViewParametersTagger
+        arguments: ['@ezplatform.view_cache.response_tagger.dispatcher']
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
     ezplatform.view_cache.response_tagger.content_info:
         class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger
         tags:

--- a/src/ResponseTagger/Delegator/DispatcherTagger.php
+++ b/src/ResponseTagger/Delegator/DispatcherTagger.php
@@ -26,5 +26,7 @@ class DispatcherTagger implements ResponseTagger
         foreach ($this->taggers as $tagger) {
             $tagger->tag($configurator, $response, $value);
         }
+
+        return $this;
     }
 }

--- a/src/ResponseTagger/Delegator/ViewParametersTagger.php
+++ b/src/ResponseTagger/Delegator/ViewParametersTagger.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+
+class ViewParametersTagger implements ResponseTagger
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger
+     */
+    private $dispatcherTagger;
+
+    public function __construct(ResponseTagger $dispatcherTagger)
+    {
+        $this->dispatcherTagger = $dispatcherTagger;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $view)
+    {
+        if (!$view instanceof View) {
+            return $this;
+        }
+
+        foreach ($view->getParameters() as $parameter) {
+            if (!$parameter instanceof ValueObject) {
+                continue;
+            }
+
+            $this->dispatcherTagger->tag($configurator, $response, $parameter);
+        }
+
+        return $this;
+    }
+}

--- a/src/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/ResponseTagger/Value/ContentInfoTagger.php
@@ -23,5 +23,7 @@ class ContentInfoTagger implements ResponseTagger
         if ($value->mainLocationId) {
             $configurator->addTags($response, ['location-' . $value->mainLocationId]);
         }
+
+        return $this;
     }
 }


### PR DESCRIPTION
Tags the response with any Repository Value Object added to the response. This should make view cache expire based on the objects actually used to render the response.

### Tasks
- [ ] Test in real life
- [ ] Add behat scenario
- [ ] Consider inspecting array parameters for `ValueObject` items. This would cover inline listing of objects (as opposed to view inclusion for ESI usage)