### PR TITLE
EZP-27713: As a Developer I want HttpCache to handle RemoveTranslationSignal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.7",
+        "ezsystems/ezpublish-kernel": "^6.7@dev",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "symfony/symfony": "^2.7 | ^3.1"
     },

--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -112,6 +112,14 @@ services:
         tags:
             - { name: ezpublish.api.slot, signal: TrashService\RecoverSignal }
 
+    ezplatform.http_cache.signalslot.remove_translation:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\RemoveTranslationSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        arguments:
+            - "@ezpublish.spi.persistence.cache.locationHandler"
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\RemoveTranslationSignal }
+
     # Content Type
     ezplatform.http_cache.signalslot.publish_content_type:
         class: EzSystems\PlatformHttpCacheBundle\SignalSlot\PublishContentTypeSlot

--- a/src/SignalSlot/RemoveTranslationSlot.php
+++ b/src/SignalSlot/RemoveTranslationSlot.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
+
+class RemoveTranslationSlot extends AbstractContentSlot
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @param \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface $purgeClient
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $spiLocationHandler
+     */
+    public function __construct(
+        PurgeClientInterface $purgeClient,
+        SPILocationHandler $spiLocationHandler
+    ) {
+        parent::__construct($purgeClient);
+        $this->locationHandler = $spiLocationHandler;
+    }
+
+    /**
+     * Checks if $signal is supported by this handler.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return bool
+     */
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\RemoveTranslationSignal;
+    }
+
+    /**
+     * Generate tags for content, relation, locations and parent locations.
+     *
+     * RemoveTranslationSignal doesn't provide locationId, so Locations need to be fetched
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return array
+     */
+    protected function generateTags(Signal $signal)
+    {
+        // aligned with PublishVersionSlot as translation removal is essentially publishing new Version.
+        $tags = parent::generateTags($signal);
+        foreach ($this->locationHandler->loadLocationsByContent($signal->contentId) as $location) {
+            // self
+            $tags[] = 'location-' . $location->id;
+            // children
+            $tags[] = 'parent-' . $location->id;
+            // parent
+            $tags[] = 'location-' . $location->parentId;
+            // siblings
+            $tags[] = 'parent-' . $location->parentId;
+        }
+
+        return $tags;
+    }
+}

--- a/tests/SignalSlot/AbstractSlotTest.php
+++ b/tests/SignalSlot/AbstractSlotTest.php
@@ -8,7 +8,7 @@
  */
 namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
 
-use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
 use PHPUnit_Framework_TestCase;
 
 abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
@@ -16,7 +16,7 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
     /** @var \EzSystems\PlatformHttpCacheBundle\SignalSlot\AbstractSlot */
     protected $slot;
 
-    /** @var \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $purgeClientMock;
 
     private $signal;

--- a/tests/SignalSlot/RemoveTranslationSlotTest.php
+++ b/tests/SignalSlot/RemoveTranslationSlotTest.php
@@ -24,6 +24,16 @@ class RemoveTranslationSlotTest extends AbstractContentSlotTest
      */
     private $locationHandlerMock;
 
+    /**
+     * Check if required signal exists due to BC.
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists(RemoveTranslationSignal::class)) {
+            self::markTestSkipped('RemoveTranslationSignal does not exist');
+        }
+    }
+
     public function setUp()
     {
         $this->locationHandlerMock = $this->getMock(LocationHandler::class);

--- a/tests/SignalSlot/RemoveTranslationSlotTest.php
+++ b/tests/SignalSlot/RemoveTranslationSlotTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\RemoveTranslationSlot;
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\RemoveTranslationSignal;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+
+/**
+ * Test RemoveTranslationSlot for HttpCache.
+ */
+class RemoveTranslationSlotTest extends AbstractContentSlotTest
+{
+    protected $locationId = 43;
+    protected $parentLocationId = 45;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $locationHandlerMock;
+
+    public function setUp()
+    {
+        $this->locationHandlerMock = $this->getMock(LocationHandler::class);
+        parent::setUp();
+    }
+
+    /**
+     * @dataProvider getReceivedSignals
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function testReceivePurgesCacheForTags($signal)
+    {
+        $this->locationHandlerMock
+            ->expects($this->once())
+            ->method('loadLocationsByContent')
+            ->with($this->contentId)
+            ->willReturn(
+                [
+                    new Location(
+                        [
+                            'id' => $this->locationId,
+                            'parentId' => $this->parentLocationId,
+                        ]
+                    ),
+                ]
+            );
+
+        parent::testReceivePurgesCacheForTags($signal);
+    }
+
+    public function createSignal()
+    {
+        return new RemoveTranslationSignal(
+            [
+                'contentId' => $this->contentId,
+                'languageCode' => 'eng-US',
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        return [
+            'content-' . $this->contentId,
+            'relation-' . $this->contentId,
+            'location-' . $this->locationId,
+            'parent-' . $this->locationId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
+        ];
+    }
+
+    public function getSlotClass()
+    {
+        return RemoveTranslationSlot::class;
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return [RemoveTranslationSignal::class];
+    }
+
+    protected function createSlot()
+    {
+        return new RemoveTranslationSlot(
+            $this->purgeClientMock,
+            $this->locationHandlerMock
+        );
+    }
+}


### PR DESCRIPTION
Implements [EZP-27713](https://jira.ez.no/browse/EZP-27713)
----

This PR implements HttpCache `RemoveTranslationSlot` for `RemoveTranslationSignal` introduced in ezsystems/ezpublish-kernel#2031.

Similar slot for deprecated EzPublishCoreBundle HttpCache was introduced in ezsystems/ezpublish-kernel#2062.

**TODO**:
- [x] Implement `RemoveTranslationSlot` for HttpCache.
- [x] Add unit test for new Slot.
- [x] Perform negative (no Slot) test to confirm this solution works in real env as expected.
- [x] Get feedback on `composer.json` changes