### PR TITLE
Use PHPUnit v5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "symfony/symfony": "^2.7 | ^3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7.0",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*",
+        "phpunit/phpunit": "^5.7",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0",
         "phpspec/phpspec": "^3.2",
         "memio/spec-gen": "^0.6"
     },

--- a/tests/Proxy/TagAwareStoreTest.php
+++ b/tests/Proxy/TagAwareStoreTest.php
@@ -10,9 +10,10 @@ namespace EzSystems\PlatformHttpCacheBundle\Tests\Proxy;
 
 use EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore;
 use Symfony\Component\HttpFoundation\Request;
-use PHPUnit_Framework_TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
 
-class TagAwareStoreTest extends PHPUnit_Framework_TestCase
+class TagAwareStoreTest extends TestCase
 {
     /**
      * @var \EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore
@@ -74,7 +75,7 @@ class TagAwareStoreTest extends PHPUnit_Framework_TestCase
      */
     private function getFilesystemMock()
     {
-        return $this->getMock('Symfony\\Component\\Filesystem\\Filesystem');
+        return $this->createMock(Filesystem::class);
     }
 
     public function testPurgeByRequestSingleLocation()

--- a/tests/PurgeClient/FOSPurgeClientTest.php
+++ b/tests/PurgeClient/FOSPurgeClientTest.php
@@ -11,10 +11,10 @@ namespace EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\FOSPurgeClient;
 use FOS\HttpCache\ProxyClient\ProxyClientInterface;
 use FOS\HttpCacheBundle\CacheManager;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class FOSPurgeClientTest extends PHPUnit_Framework_TestCase
+class FOSPurgeClientTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -32,8 +32,8 @@ class FOSPurgeClientTest extends PHPUnit_Framework_TestCase
         $this->cacheManager = $this->getMockBuilder(CacheManager::class)
             ->setConstructorArgs(
                 array(
-                    $this->getMock(ProxyClientInterface::class),
-                    $this->getMock(
+                    $this->createMock(ProxyClientInterface::class),
+                    $this->createMock(
                         UrlGeneratorInterface::class
                     ),
                 )

--- a/tests/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/PurgeClient/LocalPurgeClientTest.php
@@ -22,10 +22,10 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests;
 
 use EzSystems\PlatformHttpCacheBundle\RequestAwarePurger;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-class LocalPurgeClientTest extends PHPUnit_Framework_TestCase
+class LocalPurgeClientTest extends TestCase
 {
     public function testPurge()
     {
@@ -33,7 +33,7 @@ class LocalPurgeClientTest extends PHPUnit_Framework_TestCase
         $expectedBanRequest = Request::create('http://localhost', 'PURGE');
         $expectedBanRequest->headers->set('key', 'location-123 location-456 location-789');
 
-        $cacheStore = $this->getMock(RequestAwarePurger::class);
+        $cacheStore = $this->createMock(RequestAwarePurger::class);
         $cacheStore
             ->expects($this->once())
             ->method('purgeByRequest')

--- a/tests/SignalSlot/AbstractSlotTest.php
+++ b/tests/SignalSlot/AbstractSlotTest.php
@@ -9,9 +9,9 @@
 namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
 
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
+abstract class AbstractSlotTest extends TestCase
 {
     /** @var \EzSystems\PlatformHttpCacheBundle\SignalSlot\AbstractSlot */
     protected $slot;
@@ -23,7 +23,7 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->purgeClientMock = $this->getMock(PurgeClientInterface::class);
+        $this->purgeClientMock = $this->createMock(PurgeClientInterface::class);
         $this->slot = $this->createSlot();
         $this->signal = $this->createSignal();
     }

--- a/tests/SignalSlot/PublishVersionSlotTest.php
+++ b/tests/SignalSlot/PublishVersionSlotTest.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal;
 use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler;
 
 class PublishVersionSlotTest extends AbstractContentSlotTest
 {
@@ -38,7 +39,7 @@ class PublishVersionSlotTest extends AbstractContentSlotTest
     {
         $class = $this->getSlotClass();
         if ($this->spiLocationHandlerMock === null) {
-            $this->spiLocationHandlerMock = $this->getMock('eZ\Publish\SPI\Persistence\Content\Location\Handler');
+            $this->spiLocationHandlerMock = $this->createMock(Handler::class);
         }
 
         return new $class($this->purgeClientMock, $this->spiLocationHandlerMock);

--- a/tests/SignalSlot/RemoveTranslationSlotTest.php
+++ b/tests/SignalSlot/RemoveTranslationSlotTest.php
@@ -36,7 +36,7 @@ class RemoveTranslationSlotTest extends AbstractContentSlotTest
 
     public function setUp()
     {
-        $this->locationHandlerMock = $this->getMock(LocationHandler::class);
+        $this->locationHandlerMock = $this->createMock(LocationHandler::class);
         parent::setUp();
     }
 


### PR DESCRIPTION
This PR resolves:
* `phpunit\phpunit` constraint now requires `^5.7`
* all test cases updated to use namespaced `TestCase`
* removed all deprecated `getMock` method calls
* mocks now use PHP class name constants