### PR TITLE
[Composer] Allowed ezpublish-kernel ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.7@dev",
+        "ezsystems/ezpublish-kernel": "^6.7@dev || ^7.0",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "symfony/symfony": "^2.7 | ^3.1"
     },


### PR DESCRIPTION
This PR allows `ezpublish-kernel:^7.0@dev` for `ezplatform-http-cache`.

Reason: Right now we have to make workaround to install `ezplatform:2.0` meta-repository dependencies by setting requirement for `ezpublish-kernel` in the form of `7.0.x-dev as 6.99.x-dev` instead of simply `^7.0@dev`. This change solves that partially (see also: ezsystems/ez-support-tools#24).