### PR TITLE
EZP-28160: Added HTTP Cache purge after copying subtree

### DIFF
--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -16,6 +16,12 @@ services:
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\CopyContentSignal }
 
+    ezplatform.http_cache.signalslot.copy_subtree:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\CopySubtreeSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\CopySubtreeSignal }
+
     ezplatform.http_cache.signalslot.create_location:
         class: EzSystems\PlatformHttpCacheBundle\SignalSlot\CreateLocationSlot
         parent: ezplatform.http_cache.signalslot.abstract_content

--- a/src/SignalSlot/CopySubtreeSlot.php
+++ b/src/SignalSlot/CopySubtreeSlot.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling CopySubtreeSignal.
+ */
+class CopySubtreeSlot extends AbstractContentSlot
+{
+    protected function generateTags(Signal $signal)
+    {
+        /** @var \eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal $signal */
+        return [
+            'location-' . $signal->targetParentLocationId,
+            'parent-' . $signal->targetParentLocationId,
+        ];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\CopySubtreeSignal;
+    }
+}

--- a/tests/SignalSlot/CopySubtreeSlotTest.php
+++ b/tests/SignalSlot/CopySubtreeSlotTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\CopySubtreeSlot;
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal;
+
+class CopySubtreeSlotTest extends AbstractContentSlotTest
+{
+    private $subtreeId = 67;
+    private $targetParentLocationId = 43;
+    private $targetNewSubtreeId = 45;
+
+    public function createSignal()
+    {
+        return new CopySubtreeSignal([
+            'subtreeId' => $this->subtreeId,
+            'targetParentLocationId' => $this->targetParentLocationId,
+            'targetNewSubtreeId' => $this->targetNewSubtreeId
+        ]);
+    }
+
+    public function generateTags()
+    {
+        return [
+            'location-' . $this->targetParentLocationId,
+            'parent-' . $this->targetParentLocationId
+        ];
+    }
+
+    public function getSlotClass()
+    {
+        return CopySubtreeSlot::class;
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return [CopySubtreeSignal::class];
+    }
+
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28160

## Description

This PR adds a missing HTTP Cache purging after the subtree copying. Discovered while testing https://github.com/ezsystems/PlatformUIBundle/pull/893#issuecomment-340418960

## Steps to reproduce

> 1. Create the following structure:
> a) Home/Folder A
> b) Home/Folder A/Folder B
> c) Home/Folder A/Folder B/Article
> 2. Copy subtree Folder B into Folder A
> 3. Copy subtree Folder B into Folder A again
> 4. Go to location view for Folder A
> 5. The pagination is broken (see attached screenshot) because childCount in response to GET /api/ezp/v2/content/location/X/Y is out of date.