### PR TITLE
Purge type HTTP just does not work

### DIFF
--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -41,6 +41,11 @@ class KernelPass implements CompilerPassInterface
             return true;
         }));
         $container->getDefinition('cache_clearer')->setArguments($arguments);
+        
+        $container->getDefinition('cache_clearer')->setArguments($arguments);
+        if ($container->getAlias('ezpublish.http_cache.purge_client') == 'ezpublish.http_cache.purge_client.fos') {
+            $container->setAlias('ezplatform.http_cache.purge_client', 'ezplatform.http_cache.purge_client.fos');
+        }
     }
 
     /**


### PR DESCRIPTION
This bundle relies on `ezplatform.http_cache.purge_client` but the code in ez kernel sets `ezpublish.http_cache.purge_client` 
Wiring has not been done, which also mean, that this feature was not tested.
