### PR TITLE
EZP-28160: Wrong slot configuration for HTTP cache purge after copying subtree

### DIFF
--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -20,7 +20,7 @@ services:
         class: EzSystems\PlatformHttpCacheBundle\SignalSlot\CopySubtreeSlot
         parent: ezplatform.http_cache.signalslot.abstract_content
         tags:
-            - { name: ezpublish.api.slot, signal: ContentService\CopySubtreeSignal }
+            - { name: ezpublish.api.slot, signal: LocationService\CopySubtreeSignal }
 
     ezplatform.http_cache.signalslot.create_location:
         class: EzSystems\PlatformHttpCacheBundle\SignalSlot\CreateLocationSlot


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28160

## Description

https://github.com/ezsystems/ezplatform-http-cache/pull/18 added 
`EzSystems\PlatformHttpCacheBundle\SignalSlot\CopySubtreeSlot`, which should be connected to `LocationService\CopySubtreeSignal` instead of `ContentService\CopySubtreeSignal`. 

_I'm not sure how I've overlooked this while preparing a commit. My fault._



