### PR TITLE
EZP-28183: Requests (incl from REST) with X-Location-Id not tagged

### DIFF
--- a/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace spec\EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class XLocationIdResponseSubscriberSpec extends ObjectBehavior
+{
+    public function let(
+        FilterResponseEvent $event,
+        Response $response,
+        ResponseHeaderBag $responseHeaders
+    ) {
+        $response->headers = $responseHeaders;
+        $event->getResponse()->willReturn($response);
+
+        $this->beConstructedWith('Surrogate-Key');
+    }
+
+    public function it_does_not_rewrite_header_if_there_is_none(
+        FilterResponseEvent $event,
+        ResponseHeaderBag $responseHeaders
+    ) {
+        $responseHeaders->has('X-Location-Id')->willReturn(false);
+        $responseHeaders->set()->shouldNotBecalled();
+
+        $this->rewriteCacheHeader($event);
+    }
+
+    public function it_rewrite_header_if_there(
+        FilterResponseEvent $event,
+        ResponseHeaderBag $responseHeaders
+    ) {
+        $responseHeaders->has('X-Location-Id')->willReturn(true);
+        $responseHeaders->get('X-Location-Id')->willReturn('123');
+        $responseHeaders->has('Surrogate-Key')->willReturn(false);
+
+        $responseHeaders->set('Surrogate-Key', ['location-123'])->willReturn(null);
+        $responseHeaders->remove('X-Location-Id')->willReturn(null);
+
+        $this->rewriteCacheHeader($event);
+    }
+
+    public function it_rewrite_header_also_in_unofficial_plural_form_and_merges_exisitng_value(
+        FilterResponseEvent $event,
+        ResponseHeaderBag $responseHeaders
+    ) {
+        $responseHeaders->has('X-Location-Id')->willReturn(true);
+        $responseHeaders->get('X-Location-Id')->willReturn('123,34');
+        $responseHeaders->has('Surrogate-Key')->willReturn(true);
+        $responseHeaders->get('Surrogate-Key', null, false)->willReturn(['content-44']);
+
+        $responseHeaders->set('Surrogate-Key', ['content-44', 'location-123', 'location-34'])->willReturn(null);
+        $responseHeaders->remove('X-Location-Id')->willReturn(null);
+
+        $this->rewriteCacheHeader($event);
+    }
+}

--- a/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
@@ -18,7 +18,6 @@ class EzSystemsPlatformHttpCacheExtension extends Extension implements PrependEx
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('default_settings.yml');
         $loader->load('services.yml');
         $loader->load('slot.yml');
         $loader->load('view_cache.yml');
@@ -26,7 +25,11 @@ class EzSystemsPlatformHttpCacheExtension extends Extension implements PrependEx
 
     public function prepend(ContainerBuilder $container)
     {
-        // Default settings for FOSHttpCacheBundle
+        // Load params early as we use them in below
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('default_settings.yml');
+
+        // Override default settings for FOSHttpCacheBundle
         $configFile = __DIR__ . '/../Resources/config/fos_http_cache.yml';
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('fos_http_cache', $config);

--- a/src/EventSubscriber/XLocationIdResponseSubscriber.php
+++ b/src/EventSubscriber/XLocationIdResponseSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Rewrites the X-Location-Id HTTP header.
+ *
+ * This is a BC layer for custom controllers (including REST server) still
+ * using X-Location-Id header which is now deprecated. For
+ * full value of tagging, see docs/using_tags.md for how to take advantage of the
+ * system.
+ */
+class XLocationIdResponseSubscriber implements EventSubscriberInterface
+{
+    const LOCATION_ID_HEADER = 'X-Location-Id';
+
+    /**
+     * @var string
+     */
+    private $tagHeader;
+
+    public function __construct($tagHeader)
+    {
+        $this->tagHeader = $tagHeader;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => ['rewriteCacheHeader', -5]];
+    }
+
+    public function rewriteCacheHeader(FilterResponseEvent $event)
+    {
+        $response = $event->getResponse();
+        if (!$response->headers->has(static::LOCATION_ID_HEADER)) {
+            return;
+        }
+
+        @trigger_error(
+            'X-Location-Id is no longer preferred way to tag content responses, see ezplatform-http-cache/docs/using_tags.md',
+            E_USER_DEPRECATED
+        );
+
+        // Map the tag, even if not officially supported, handle comma separated values as was possible with Varnish
+        $tags = array_map(
+            function ($id) {
+                return 'location-' . trim($id);
+            },
+            explode(',', $response->headers->get(static::LOCATION_ID_HEADER))
+        );
+
+        if ($response->headers->has($this->tagHeader)) {
+            $tags = array_merge($response->headers->get($this->tagHeader, null, false) , $tags);
+        }
+
+        // @todo we need to use abstract tag writer to also be able to support Fastly
+        // FOS has some stuff around this in 2.x but not in a good way in 1.x
+        $response->headers->set($this->tagHeader, array_unique($tags));
+        $response->headers->remove(static::LOCATION_ID_HEADER);
+    }
+}

--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -73,10 +73,6 @@ class TagAwareStore extends Store implements RequestAwarePurger
         $digest = $response->headers->get('X-Content-Digest');
         $tags = $response->headers->get('xkey', null, false);
 
-        if ($response->headers->has('X-Location-Id')) {
-            $tags[] = 'location-' . $response->headers->get('X-Location-Id');
-        }
-
         foreach (array_unique($tags) as $tag) {
             if (false === $this->saveTag($tag, $digest)) {
                 throw new \RuntimeException('Unable to store the cache tag meta information.');

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -1,2 +1,3 @@
 parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
+    ezplatform.http_cache.tags.header: 'xkey'

--- a/src/Resources/config/fos_http_cache.yml
+++ b/src/Resources/config/fos_http_cache.yml
@@ -14,4 +14,4 @@ tags:
     # 1. Until 2.x it is hardcoded to use comma separated list of tags, which won't work on Fastly and
     #    will conflict with the one header per key format we currently use with xkey (as per their doc)
     # 2. In FosHttpCache 1.x it is only available if proxy client is configured as "varnish" or "custom"
-    header: xkey
+    header: '%ezplatform.http_cache.tags.header%'

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -7,6 +7,12 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezplatform.x_location_id.response_subscriber:
+        class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\XLocationIdResponseSubscriber
+        arguments: ['%ezplatform.http_cache.tags.header%']
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezplatform.view_cache.response_configurator:
         class: EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator
         arguments:


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28183
>     REST request are not properly tagged and hence not purged as they should, custom controllers not using ContentView is also affected.
> Replaces #21 


@bdunogier @Plopix : Here is somewhat what I had in mind here to begin with. This approach does not need to use response tagger in a way it was made for, and does not need to force caching of all REST responses. It just does one thing, transform the old value to the new one, on top of that it triggers deprecation warning pointing to doc we will need to write on how to deal with tags... (:

Todo:
- [x] Spec
- _(separate pr)_ Doc on using tags 