### PR TITLE
EZP-28161: Enable php-cs-fixer aligned with v2.7.1 settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,35 @@
+<?php
+
+// PHP-CS-Fixer 2.x syntax
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'array_syntax' => false,
+        'simplified_null_return' => false,
+        'phpdoc_align' => false,
+        'phpdoc_separation' => false,
+        'phpdoc_to_comment' => false,
+        'cast_spaces' => false,
+        'blank_line_after_opening_tag' => false,
+        'single_blank_line_before_namespace' => false,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_no_alias_tag' => false,
+        'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude([
+                'spec',
+                'docs',
+                'features',
+                'vendor',
+            ])
+            ->files()->name('*.php')
+    )
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
-php:
-    - 5.6
-    - 7.0
+matrix:
+    include:
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
 
 # test only master (+ Pull requests)
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
         - php: 5.6
         - php: 7.0
         - php: 7.1
+          env: CHECK_CS=true
 
 # test only master (+ Pull requests)
 branches:
@@ -16,7 +17,9 @@ before_script:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - travis_retry composer install --prefer-dist --no-interaction
 
-script: php vendor/bin/phpunit --coverage-text && php vendor/bin/phpspec run --format=pretty
+script:
+    - php vendor/bin/phpunit --coverage-text && php vendor/bin/phpspec run --format=pretty
+    - if [ "$CHECK_CS" == "true" ]; then phpenv config-rm xdebug.ini && ./vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
 
 notifications:
     email: false

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "phpunit/phpunit": "^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "~1.0",
         "phpspec/phpspec": "^3.2",
+        "friendsofphp/php-cs-fixer": "~2.7.1",
         "memio/spec-gen": "^0.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
             "EzSystems\\PlatformHttpCacheBundle\\Tests\\": "tests"
         }
     },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.1.x-dev"

--- a/src/AppCache.php
+++ b/src/AppCache.php
@@ -3,7 +3,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace EzSystems\PlatformHttpCacheBundle;
 
 use eZ\Bundle\EzPublishCoreBundle\HttpCache;

--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -3,7 +3,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -38,6 +37,7 @@ class KernelPass implements CompilerPassInterface
             if ($this->isCachePurger($argument)) {
                 return false;
             }
+
             return true;
         }));
         $container->getDefinition('cache_clearer')->setArguments($arguments);

--- a/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzSystemsPlatformHttpCacheExtension.php
@@ -17,7 +17,7 @@ class EzSystemsPlatformHttpCacheExtension extends Extension implements PrependEx
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('slot.yml');
         $loader->load('view_cache.yml');
@@ -26,7 +26,7 @@ class EzSystemsPlatformHttpCacheExtension extends Extension implements PrependEx
     public function prepend(ContainerBuilder $container)
     {
         // Load params early as we use them in below
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('default_settings.yml');
 
         // Override default settings for FOSHttpCacheBundle

--- a/src/EventSubscriber/XLocationIdResponseSubscriber.php
+++ b/src/EventSubscriber/XLocationIdResponseSubscriber.php
@@ -57,7 +57,7 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
         );
 
         if ($response->headers->has($this->tagHeader)) {
-            $tags = array_merge($response->headers->get($this->tagHeader, null, false) , $tags);
+            $tags = array_merge($response->headers->get($this->tagHeader, null, false), $tags);
         }
 
         // @todo we need to use abstract tag writer to also be able to support Fastly

--- a/tests/Proxy/TagAwareStoreTest.php
+++ b/tests/Proxy/TagAwareStoreTest.php
@@ -67,7 +67,7 @@ class TagAwareStoreTest extends TestCase
 
         $path = $this->store->getPath("$prefix/en" . sha1('someContent'));
         $this->assertStringStartsWith(__DIR__ . "/$prefix", $path);
-        $this->assertFalse(file_exists($lockFile));
+        $this->assertFileNotExists($lockFile);
     }
 
     /**

--- a/tests/SignalSlot/CopySubtreeSlotTest.php
+++ b/tests/SignalSlot/CopySubtreeSlotTest.php
@@ -22,7 +22,7 @@ class CopySubtreeSlotTest extends AbstractContentSlotTest
         return new CopySubtreeSignal([
             'subtreeId' => $this->subtreeId,
             'targetParentLocationId' => $this->targetParentLocationId,
-            'targetNewSubtreeId' => $this->targetNewSubtreeId
+            'targetNewSubtreeId' => $this->targetNewSubtreeId,
         ]);
     }
 
@@ -30,7 +30,7 @@ class CopySubtreeSlotTest extends AbstractContentSlotTest
     {
         return [
             'location-' . $this->targetParentLocationId,
-            'parent-' . $this->targetParentLocationId
+            'parent-' . $this->targetParentLocationId,
         ];
     }
 
@@ -43,5 +43,4 @@ class CopySubtreeSlotTest extends AbstractContentSlotTest
     {
         return [CopySubtreeSignal::class];
     }
-
 }


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161)

This PR introduces `.php_cs` config and aligns CS.
To simplify fixing code it adds dev dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] Create php-cs-fixer config (`.php_cs`)
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`
- [x] Fix CS
- [x] Create test matrix with PHP 7.1 testing enabled.
- [x] Enable CS check on Travis