### PR TITLE
Fixed SetEnv syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For PHP's internal server you can set it as shell environment variable before st
 For Apache, with the default eZ Platform virtual host definition, uncomment the `SetEnv` lines for the two
 variables above in your virtualhost, and set the values accordingly:
 
-    SetEnv SYMFONY_HTTP_CACHE_CLASS='EzSystems\PlatformHttpCacheBundle\AppCache'
+    SetEnv SYMFONY_HTTP_CACHE_CLASS 'EzSystems\PlatformHttpCacheBundle\AppCache'
 
 For Nginx, set the variables using `fastcgi_param`:
 


### PR DESCRIPTION
according to https://httpd.apache.org/docs/2.4/mod/mod_env.html there should be no equals sign when defining an Env Variable