### PR TITLE
Definded handling of tag header in a separate TagHandlerInterface

### DIFF
--- a/spec/DependencyInjection/Compiler/KernelPassSpec.php
+++ b/spec/DependencyInjection/Compiler/KernelPassSpec.php
@@ -52,6 +52,8 @@ class KernelPassSpec extends ObjectBehavior
             ]
         ])->shouldBeCalled();
 
+        $container->getParameter('purge_type')->shouldBeCalled();
+
         $this->process($container);
     }
 }

--- a/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
@@ -10,18 +10,20 @@ use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use EzSystems\PlatformHttpCacheBundle\Handler\TagHandlerInterface;
 
 class XLocationIdResponseSubscriberSpec extends ObjectBehavior
 {
     public function let(
         FilterResponseEvent $event,
         Response $response,
+        TagHandlerInterface $tagHandler,
         ResponseHeaderBag $responseHeaders
     ) {
         $response->headers = $responseHeaders;
         $event->getResponse()->willReturn($response);
 
-        $this->beConstructedWith('Surrogate-Key');
+        $this->beConstructedWith($tagHandler);
     }
 
     public function it_does_not_rewrite_header_if_there_is_none(

--- a/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
+++ b/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
@@ -6,13 +6,14 @@ use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseC
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use EzSystems\PlatformHttpCacheBundle\Handler\TagHandlerInterface;
 
 class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
 {
-    public function let(Response $response, ResponseHeaderBag $headers)
+    public function let(Response $response, ResponseHeaderBag $headers, TagHandlerInterface $tagHandler)
     {
         $response->headers = $headers;
-        $this->beConstructedWith(true, true, 30);
+        $this->beConstructedWith(true, true, 30, $tagHandler);
     }
 
     public function it_is_initializable()
@@ -20,33 +21,33 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $this->shouldHaveType(ConfigurableResponseCacheConfigurator::class);
     }
 
-    public function it_sets_cache_control_to_public_if_viewcache_is_enabled(Response $response)
+    public function it_sets_cache_control_to_public_if_viewcache_is_enabled(Response $response, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(true, false, 0);
+        $this->beConstructedWith(true, false, 0, $tagHandler);
         $this->enableCache($response);
 
         $response->setPublic()->shouldHaveBeenCalled();
     }
 
-    public function it_does_not_set_cache_control_if_viewcache_is_disabled(Response $response)
+    public function it_does_not_set_cache_control_if_viewcache_is_disabled(Response $response, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(false, false, 0);
+        $this->beConstructedWith(false, false, 0, $tagHandler);
         $this->enableCache($response);
 
         $response->setPublic()->shouldNotHaveBeenCalled();
     }
 
-    public function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(Response $response)
+    public function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(Response $response, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(true, false, 30);
+        $this->beConstructedWith(true, false, 30, $tagHandler);
         $this->setSharedMaxAge($response);
 
         $response->setSharedMaxAge(30)->shouldNotHaveBeenCalled();
     }
 
-    public function it_does_not_set_shared_maxage_if_it_is_already_set_in_the_response(Response $response, ResponseHeaderBag $headers)
+    public function it_does_not_set_shared_maxage_if_it_is_already_set_in_the_response(Response $response, ResponseHeaderBag $headers, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(true, true, 30);
+        $this->beConstructedWith(true, true, 30, $tagHandler);
         $headers->hasCacheControlDirective('s-maxage')->willReturn(true);
 
         $this->setSharedMaxAge($response);
@@ -54,9 +55,9 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setSharedMaxAge($response, 30)->shouldNotHaveBeenCalled();
     }
 
-    public function it_sets_shared_maxage(Response $response, ResponseHeaderBag $headers)
+    public function it_sets_shared_maxage(Response $response, ResponseHeaderBag $headers, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(true, true, 30);
+        $this->beConstructedWith(true, true, 30, $tagHandler);
         $headers->hasCacheControlDirective('s-maxage')->willReturn(false);
 
         $this->setSharedMaxAge($response);
@@ -64,17 +65,17 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setSharedMaxAge(30)->shouldHaveBeenCalled();
     }
 
-    public function it_does_not_add_tags_if_viewcache_is_disabled(Response $response, ResponseHeaderBag $headers)
+    public function it_does_not_add_tags_if_viewcache_is_disabled(Response $response, ResponseHeaderBag $headers, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(false, false, 0);
+        $this->beConstructedWith(false, false, 0, $tagHandler);
         $this->addTags($response, ['foo-1', 'bar-2']);
 
         $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();
     }
 
-    public function it_adds_tags_to_the_xkey_header(Response $response, ResponseHeaderBag $headers)
+    public function it_adds_tags_to_the_xkey_header(Response $response, ResponseHeaderBag $headers, TagHandlerInterface $tagHandler)
     {
-        $this->beConstructedWith(false, false, 0);
+        $this->beConstructedWith(false, false, 0, $tagHandler);
         $this->addTags($response, ['foo-1', 'bar-2']);
 
         $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();

--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -7,6 +7,8 @@ namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use EzSystems\PlatformHttpCacheBundle\Handler\TagHandler;
 
 /**
  * Disables some of the http-cache services declared by the kernel so that
@@ -44,6 +46,14 @@ class KernelPass implements CompilerPassInterface
 
         if ($container->getAlias('ezpublish.http_cache.purge_client') == 'ezpublish.http_cache.purge_client.fos') {
             $container->setAlias('ezplatform.http_cache.purge_client', 'ezplatform.http_cache.purge_client.fos');
+        }
+
+        $purgeType = $container->getParameter('purge_type');
+        if ($purgeType === 'http') {
+            // Injecting our own Tag handler
+            $definition = $container->getDefinition('fos_http_cache.handler.tag_handler');
+            $definition->setClass(TagHandler::class);
+            $definition->addArgument(new Reference('ezplatform.http_cache.purge_client.fos'));
         }
     }
 

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\Handler;
+
+use FOS\HttpCacheBundle\Handler\TagHandler as FOSTagHandler;
+use Symfony\Component\HttpFoundation\Response;
+use FOS\HttpCacheBundle\CacheManager;
+
+/**
+ * This is not a full implementation of FOS TagHandler
+ * It extends extends TagHandler and implements invalidateTags() and purge() so that you may run
+ * php app/console fos:httpcache:invalidate:tag <tag>
+ *
+ * It implements tagResponse() to make sure TagSubscriber( a FOS event listener ) do not try to tag the response.
+ * as we use ConfigurableResponseCacheConfigurator for that purpose instead.
+ *
+ */
+class TagHandler extends FOSTagHandler implements TagHandlerInterface
+{
+    private $cacheManager;
+    private $purgeClient;
+    private $tagsHeader;
+
+    public function __construct(CacheManager $cacheManager, $tagsHeader, $purgeClient)
+    {
+        $this->cacheManager = $cacheManager;
+        $this->tagsHeader = $tagsHeader;
+        $this->purgeClient = $purgeClient;
+    }
+
+    public function invalidateTags(array $tags)
+    {
+        $this->purge($tags);
+    }
+
+    public function purge($tags)
+    {
+        $this->purgeClient->purge($tags);
+    }
+
+    public function tagResponse(Response $response, $replace = false)
+    {
+        return $this;
+    }
+
+    public function addTagHeaders(Response $response, array $tags)
+    {
+        $response->headers->set($this->tagsHeader, $tags, false);
+    }
+}

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -9,11 +9,10 @@ use FOS\HttpCacheBundle\CacheManager;
 /**
  * This is not a full implementation of FOS TagHandler
  * It extends extends TagHandler and implements invalidateTags() and purge() so that you may run
- * php app/console fos:httpcache:invalidate:tag <tag>
+ * php app/console fos:httpcache:invalidate:tag <tag>.
  *
  * It implements tagResponse() to make sure TagSubscriber( a FOS event listener ) do not try to tag the response.
  * as we use ConfigurableResponseCacheConfigurator for that purpose instead.
- *
  */
 class TagHandler extends FOSTagHandler implements TagHandlerInterface
 {

--- a/src/Handler/TagHandlerInterface.php
+++ b/src/Handler/TagHandlerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\Handler;
+
+use Symfony\Component\HttpFoundation\Response;
+
+interface TagHandlerInterface
+{
+    public function addTagHeaders(Response $response, array $tags);
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -24,3 +24,11 @@ services:
     ezplatform.http_cache.tag_aware_store:
         class: EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore
         arguments: ["%ezplatform.http_cache.store.root%"]
+
+    ezplatform.http_cache.tag_handler:
+        class: EzSystems\PlatformHttpCacheBundle\Handler\TagHandler
+        arguments:
+         - '@ezplatform.http_cache.cache_manager'
+         - '%ezplatform.http_cache.tags.header%'
+         - '@ezplatform.http_cache.purge_client'
+

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -9,7 +9,7 @@ services:
 
     ezplatform.x_location_id.response_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\XLocationIdResponseSubscriber
-        arguments: ['%ezplatform.http_cache.tags.header%']
+        arguments: ['@ezplatform.http_cache.tag_handler']
         tags:
             - { name: kernel.event_subscriber }
 
@@ -19,6 +19,7 @@ services:
             - '$content.view_cache$'
             - '$content.ttl_cache$'
             - '$content.default_ttl$'
+            - '@ezplatform.http_cache.tag_handler'
 
     ezplatform.view_cache.response_tagger.dispatcher:
         class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\DispatcherTagger

--- a/src/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
+++ b/src/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
@@ -6,6 +6,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\ResponseConfigurator;
 
 use Symfony\Component\HttpFoundation\Response;
+use EzSystems\PlatformHttpCacheBundle\Handler\TagHandlerInterface;
 
 /**
  * A ResponseCacheConfigurator configurable by constructor arguments.
@@ -32,11 +33,17 @@ class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
      */
     private $defaultTtl;
 
-    public function __construct($enableViewCache, $enableTtlCache, $defaultTtl)
+    /**
+     * @var TagHandlerInterface
+     */
+    private $tagHandler;
+
+    public function __construct($enableViewCache, $enableTtlCache, $defaultTtl, TagHandlerInterface  $tagHandler)
     {
         $this->enableViewCache = $enableViewCache;
         $this->enableTtlCache = $enableTtlCache;
         $this->defaultTtl = $defaultTtl;
+        $this->tagHandler = $tagHandler;
     }
 
     public function enableCache(Response $response)
@@ -60,7 +67,7 @@ class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
     public function addTags(Response $response, $tags)
     {
         if ($this->enableViewCache) {
-            $response->headers->set('xkey', $tags, false);
+            $this->tagHandler->addTagHeaders($response, $tags);
         }
 
         return $this;


### PR DESCRIPTION
So, instead of dealing with xkeys in both XLocationIdResponseSubscriber and ConfigurableResponseCacheConfigurator I created a interface for it, TagHandlerInterface. Not 100% happy with then name as it might be confusing as FOS also have a TagHandler.