### PR TITLE
EZP-28126: Align AppCache with Varnish behaviour

### DIFF
--- a/src/AppCache.php
+++ b/src/AppCache.php
@@ -7,6 +7,9 @@ namespace EzSystems\PlatformHttpCacheBundle;
 
 use eZ\Bundle\EzPublishCoreBundle\HttpCache;
 use EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Custom AppCache.
@@ -18,5 +21,51 @@ class AppCache extends HttpCache
     protected function createStore()
     {
         return new TagAwareStore($this->cacheDir ?: $this->kernel->getCacheDir() . '/http_cache');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        $response = parent::handle($request, $type, $catch);
+
+        if (!$this->getKernel()->isDebug()) {
+            $this->cleanupHeadersForProd($response);
+        }
+
+        return $response;
+    }
+
+    protected function cleanupHeadersForProd(Response $response)
+    {
+        // remove headers that identify the content or internal digest info
+        $response->headers->remove('xkey');
+        $response->headers->remove('x-content-digest');
+
+        // remove vary by X-User-Hash header
+        $varyValues = [];
+        $variesByUser = false;
+        foreach ($response->getVary() as $value) {
+            if ($value === 'X-User-Hash') {
+                $variesByUser = true;
+            } else {
+                $varyValues[] = $value;
+            }
+        }
+
+        // update resulting vary header in normalized form (comma separated)
+        if (empty($varyValues)) {
+            $response->headers->remove('Vary');
+        } else {
+            $response->headers->set('Vary', implode(', ', $varyValues));
+        }
+
+        // If cache varies by user hash, then make sure other proxies don't cache this
+        if ($variesByUser) {
+            $response->setPrivate();
+            $response->headers->removeCacheControlDirective('s-maxage');
+            $response->headers->addCacheControlDirective('no-cache');
+        }
     }
 }


### PR DESCRIPTION
Like in https://github.com/ezsystems/ezplatform/pull/216, make sure to:
- mark response as private when varying on X-User-Hash


Also align with Varnish by doing the following when **not** in debug mode:
- Remove xkey headers
- Remove X-User-Hash vary by header
- Also remove the Symfony Proxy specific x-content-digest header


NOTE:
- I'm somewhat uncomfortable having this logic here and not expose ways to configure it like you can with VCL, this is why I defined it in own method so end user can overload it.
- Also could perhaps better make it clear how you can see the raw response, maybe have a `X-Debug-Hint` header saying you can enable kernel debug to get the raw backend response headers, but also a bit strange to have this in prod.