### PR TITLE
Add support for purging several tags at once with Varnish

### DIFF
--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -1,3 +1,7 @@
 parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ezplatform.http_cache.tags.header: 'xkey'
+    # In case VCL is altered to use different purge header, then the default "key"
+    ezplatform.http_cache.varnish.purge_header: 'key'
+    # For use when running with varnish modules 0.9.x which does not support purging by several headers
+    ezplatform.http_cache.varnish.one_purge_per_tag: false

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -12,7 +12,10 @@ services:
 
     ezplatform.http_cache.purge_client.varnish:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishPurgeClient
-        arguments: ['@ezplatform.http_cache.cache_manager']
+        arguments:
+            - '@ezplatform.http_cache.cache_manager'
+            - '%ezplatform.http_cache.varnish.purge_header%'
+            - '%ezplatform.http_cache.varnish.one_purge_per_tag%'
         tags:
             - {name: ezplatform.http_cache.purge_client, purge_type: http}
             - {name: ezplatform.http_cache.purge_client, purge_type: varnish}


### PR DESCRIPTION
Varnish modules v0.10.2 and higher supports purging several tags at once, so use that by default.
Also allow to configure the purge header used by Varnish proxy purger