### PR TITLE
Exposing ezplatform.http_cache.purge_type parameter for 3rd party drivers

### DIFF
--- a/spec/DependencyInjection/Compiler/KernelPassSpec.php
+++ b/spec/DependencyInjection/Compiler/KernelPassSpec.php
@@ -52,6 +52,9 @@ class KernelPassSpec extends ObjectBehavior
             ]
         ])->shouldBeCalled();
 
+        $container->getParameter('ezpublish.http_cache.purge_type')->shouldBeCalled();
+        $container->setParameter('ezplatform.http_cache.purge_type', null)->shouldBeCalled();
+
         $this->process($container);
     }
 }

--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -41,6 +41,9 @@ class KernelPass implements CompilerPassInterface
             return true;
         }));
         $container->getDefinition('cache_clearer')->setArguments($arguments);
+
+        // Let's re-export purge_type setting so that driver's don't have to depend on kernel in order to acquire it
+        $container->setParameter('ezplatform.http_cache.purge_type', $container->getParameter('ezpublish.http_cache.purge_type'));
     }
 
     /**

--- a/src/DependencyInjection/Compiler/KernelPass.php
+++ b/src/DependencyInjection/Compiler/KernelPass.php
@@ -26,6 +26,17 @@ class KernelPass implements CompilerPassInterface
             }
         }
         $container->removeAlias('ezpublish.http_cache.purger');
+        $this->symfonyPre34BC($container);
+
+        // Let's re-export purge_type setting so that driver's don't have to depend on kernel in order to acquire it
+        $container->setParameter('ezplatform.http_cache.purge_type', $container->getParameter('ezpublish.http_cache.purge_type'));
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    protected function symfonyPre34BC(ContainerBuilder $container)
+    {
         $arguments = $container->getDefinition('cache_clearer')->getArguments();
 
         // BC Symfony < 3.4, as of 3.4 and up handles this itself, on lower versions we need to adjust the arguments manually
@@ -41,9 +52,6 @@ class KernelPass implements CompilerPassInterface
             return true;
         }));
         $container->getDefinition('cache_clearer')->setArguments($arguments);
-
-        // Let's re-export purge_type setting so that driver's don't have to depend on kernel in order to acquire it
-        $container->setParameter('ezplatform.http_cache.purge_type', $container->getParameter('ezpublish.http_cache.purge_type'));
     }
 
     /**


### PR DESCRIPTION
It might be needed for 3rd party drivers to acquire the purge_type setting. With this new parameter you may get it without depending on kernel