### PR TITLE
Migrated http_cache configuration from kernel

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,0 +1,71 @@
+# Extending ezplatform-http-cache
+
+## Registering custom configuration
+This package defines the `http_cache` configuration blocks of the ezplatform semantic configuration:
+
+```yaml
+ezpublish:
+  system:
+    default:
+      http_cache:
+        purge_servers: []
+```
+
+For extensions that require extra siteaccess aware configuration for HTTP cache features,
+an extension points exists. Instead of registering a new Config Parser with the `ezpublish`
+container extension, one should do so on the `ezplatform_http_cache` one.
+
+```php
+class MyCustomBundle
+{
+  public function build(ContainerBuilder $container)
+  {
+    $cacheExtension = $container->getExtension('ez_platform_http_cache');
+    $cacheExtension->addExtraConfigParser(new CustomConfigParser());
+  }
+}
+```
+
+```php
+namespace MyCustomBundle\DependencyInjection\ConfigResolver;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
+
+class CustomConfigParser implements ParserInterface
+{
+  public function addSemanticConfig(NodeBuilder $nodeBuilder)
+  {
+    $nodeBuilder->addScalarNode('custom_setting')->end();
+  }
+
+  public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+  {
+    if (isset($scopeSettings['foo'])) {
+      $contextualizer->setContextualParameter('http_cache.foo', $currentScope, $scopeSettings['foo']);
+    }
+  }
+}
+```
+
+The `ParserInterface` implementation (`CustomConfigParser`) plays the same role than a regular one, with
+two exceptions:
+- in `addSemanticConfig()`, items are added to the `http_cache` node.
+- in `mapConfig()`, the provided `$scopeSettings` contains the *contents* of the `http_cache` configuration key.
+
+With the example above, `bin/console config:dump-reference ezpublish` will contain:
+
+```yaml
+ezpublish:
+    system:
+        siteaccess_name:
+            http_cache:
+
+                # This is defined by ezplatform-http-cache
+                purge_servers:
+
+                    # Examples:
+                    - http://localhost/
+                    - http://another.server/```
+                # This is defined by the example
+                foo: ~
+```

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -1,47 +1,89 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: bdunogier
- * Date: 23/11/2017
- * Time: 12:06
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\ConfigResolver;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class HttpCacheConfigParser implements ParserInterface
 {
+    /**
+     * @var ExtensionInterface
+     */
+    private $httpCacheExtension;
+
+    public function __construct(ExtensionInterface $httpCacheExtension)
+    {
+        $this->httpCacheExtension = $httpCacheExtension;
+    }
+
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {
-        $nodeBuilder
+        $subBuilder = $nodeBuilder
             ->arrayNode('http_cache')
                 ->info('Settings related to Http cache')
                 ->children()
                     ->arrayNode('purge_servers')
-                        ->info('THIS IS FROM EZPLATFORM-HTTP-CACHE ! Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
+                        ->info('Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
                         ->example(array('http://localhost/', 'http://another.server/'))
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()
-                    ->end()
-                ->end()
-            ->end();
+                    ->end();
+
+        foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
+            $extraConfigParser->addSemanticConfig($subBuilder);
+        }
+
+        $nodeBuilder->end()->end();
     }
 
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
     {
+        if (!isset($scopeSettings['http_cache'])) {
+            return;
+        }
+
         if (isset($scopeSettings['http_cache']['purge_servers'])) {
             $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
+        }
+
+        foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
+            $extraConfigParser->mapConfig($scopeSettings['http_cache'], $currentScope, $contextualizer);
         }
     }
 
     public function preMap(array $config, ContextualizerInterface $contextualizer)
     {
+        if (!isset($config['http_cache'])) {
+            return;
+        }
+
+        foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
+            $extraConfigParser->preMap($config['http_cache'], $contextualizer);
+        }
     }
 
     public function postMap(array $config, ContextualizerInterface $contextualizer)
     {
+        if (!isset($config['http_cache'])) {
+            return;
+        }
+
+        foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
+            $extraConfigParser->postMap($config['http_cache'], $contextualizer);
+        }
+    }
+
+    /**
+     * @return ParserInterface[]
+     */
+    private function getExtraConfigParsers()
+    {
+        return $this->httpCacheExtension->getExtraConfigParsers();
     }
 }

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/11/2017
+ * Time: 12:06
+ */
+
+namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\ConfigResolver;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class HttpCacheConfigParser implements ParserInterface
+{
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('http_cache')
+                ->info('Settings related to Http cache')
+                ->children()
+                    ->arrayNode('purge_servers')
+                        ->info('THIS IS FROM EZPLATFORM-HTTP-CACHE ! Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
+                        ->example(array('http://localhost/', 'http://another.server/'))
+                        ->requiresAtLeastOneElement()
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (isset($scopeSettings['http_cache']['purge_servers'])) {
+            $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
+        }
+    }
+
+    public function preMap(array $config, ContextualizerInterface $contextualizer)
+    {
+    }
+
+    public function postMap(array $config, ContextualizerInterface $contextualizer)
+    {
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,8 @@
 <?php
-
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -1,7 +1,11 @@
 <?php
-
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -12,6 +16,11 @@ use Symfony\Component\Yaml\Yaml;
 
 class EzPlatformHttpCacheExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface[]
+     */
+    private $extraConfigParsers = [];
+
     public function getAlias()
     {
         return 'ez_platform_http_cache';
@@ -39,5 +48,15 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('fos_http_cache', $config);
         $container->addResource(new FileResource($configFile));
+    }
+
+    public function addExtraConfigParser(ParserInterface $configParser)
+    {
+        $this->extraConfigParsers[] = $configParser;
+    }
+
+    public function getExtraConfigParsers()
+    {
+        return $this->extraConfigParsers;
     }
 }

--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -12,6 +12,11 @@ use Symfony\Component\Yaml\Yaml;
 
 class EzPlatformHttpCacheExtension extends Extension implements PrependExtensionInterface
 {
+    public function getAlias()
+    {
+        return 'ez_platform_http_cache';
+    }
+
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();

--- a/src/EzSystemsPlatformHttpCacheBundle.php
+++ b/src/EzSystemsPlatformHttpCacheBundle.php
@@ -7,8 +7,8 @@ use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\ResponseTagge
 use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\KernelPass;
 use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\DriverPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use EzSystems\PlatformHttpCacheBundle\DependencyInjection\EzPlatformHttpCacheExtension;
 
 class EzSystemsPlatformHttpCacheBundle extends Bundle
 {
@@ -20,10 +20,7 @@ class EzSystemsPlatformHttpCacheBundle extends Bundle
         $container->addCompilerPass(new KernelPass());
         $container->addCompilerPass(new DriverPass());
 
-        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $eZExtension */
-        $eZExtension = $container->getExtension('ezpublish');
-        $eZExtension->addConfigParser(new HttpCacheConfigParser());
-        // $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yml']);
+        $this->registerConfigParser($container);
     }
 
     public function getContainerExtensionClass()
@@ -49,5 +46,16 @@ class EzSystemsPlatformHttpCacheBundle extends Bundle
         if ($this->extension) {
             return $this->extension;
         }
+    }
+
+    public function registerConfigParser(ContainerBuilder $container)
+    {
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $eZExtension */
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addConfigParser(
+            new HttpCacheConfigParser(
+                $container->getExtension('ez_platform_http_cache')
+            )
+        );
     }
 }

--- a/src/EzSystemsPlatformHttpCacheBundle.php
+++ b/src/EzSystemsPlatformHttpCacheBundle.php
@@ -2,6 +2,7 @@
 
 namespace EzSystems\PlatformHttpCacheBundle;
 
+use EzSystems\PlatformHttpCacheBundle\DependencyInjection\ConfigResolver\HttpCacheConfigParser;
 use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\ResponseTaggersPass;
 use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\KernelPass;
 use EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\DriverPass;
@@ -18,6 +19,11 @@ class EzSystemsPlatformHttpCacheBundle extends Bundle
         $container->addCompilerPass(new ResponseTaggersPass());
         $container->addCompilerPass(new KernelPass());
         $container->addCompilerPass(new DriverPass());
+
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $eZExtension */
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addConfigParser(new HttpCacheConfigParser());
+        // $eZExtension->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yml']);
     }
 
     public function getContainerExtensionClass()

--- a/src/EzSystemsPlatformHttpCacheBundle.php
+++ b/src/EzSystemsPlatformHttpCacheBundle.php
@@ -20,8 +20,28 @@ class EzSystemsPlatformHttpCacheBundle extends Bundle
         $container->addCompilerPass(new DriverPass());
     }
 
+    public function getContainerExtensionClass()
+    {
+        return 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\EzPlatformHttpCacheExtension';
+    }
+
     public function getContainerExtension()
     {
-        return new EzPlatformHttpCacheExtension();
+        if (null === $this->extension) {
+            $extension = $this->createContainerExtension();
+
+            if (null !== $extension) {
+                if (!$extension instanceof ExtensionInterface) {
+                    throw new \LogicException(sprintf('Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.', get_class($extension)));
+                }
+                $this->extension = $extension;
+            } else {
+                $this->extension = false;
+            }
+        }
+
+        if ($this->extension) {
+            return $this->extension;
+        }
     }
 }


### PR DESCRIPTION
Moves the `http_cache` semantic configuration defined by `ezsystems/ezpublish-kernel` to this package. The semantic configuration added by the kernel gets overridden when defined in this package, and the processing of the configuration is done by both the kernel and this package.

This is done by making the `http cache` semantic config extensible by adding ConfigParsers to it instead of the kernel. See [the documentation](https://github.com/ezsystems/ezplatform-http-cache/tree/migrate_configuration/docs/extensibility.md).

### TODO
- [x] ezpublish-kernel changes
- [x] ~~Migrate container semantic settings as well~~ (task is larger than the scope of this story, even if it has potential)