### PR TITLE
EZP-28326: Use improved signals with parent id's to clear relevant cache

### DIFF
--- a/src/SignalSlot/MoveSubtreeSlot.php
+++ b/src/SignalSlot/MoveSubtreeSlot.php
@@ -20,9 +20,10 @@ class MoveSubtreeSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        // @todo Missing info to clear sibling and parent cache of old parent!
         return [
             'path-' . $signal->locationId,
+            'location-' . $signal->oldParentLocationId,
+            'parent-' . $signal->oldParentLocationId,
             'location-' . $signal->newParentLocationId,
             'parent-' . $signal->newParentLocationId,
         ];

--- a/src/SignalSlot/SwapLocationSlot.php
+++ b/src/SignalSlot/SwapLocationSlot.php
@@ -21,10 +21,16 @@ class SwapLocationSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         return [
+            'content-' . $signal->content1Id,
             'location-' . $signal->location1Id,
             'parent-' . $signal->location1Id,
+            'location-' . $signal->parentLocation1Id,
+            'parent-' . $signal->parentLocation1Id,
+            'content-' . $signal->content2Id,
             'location-' . $signal->location2Id,
             'parent-' . $signal->location2Id,
+            'location-' . $signal->parentLocation2Id,
+            'parent-' . $signal->parentLocation2Id,
         ];
     }
 

--- a/src/SignalSlot/SwapLocationSlot.php
+++ b/src/SignalSlot/SwapLocationSlot.php
@@ -22,13 +22,11 @@ class SwapLocationSlot extends AbstractContentSlot
     {
         return [
             'content-' . $signal->content1Id,
-            'location-' . $signal->location1Id,
-            'parent-' . $signal->location1Id,
+            'path-' . $signal->location1Id,
             'location-' . $signal->parentLocation1Id,
             'parent-' . $signal->parentLocation1Id,
             'content-' . $signal->content2Id,
-            'location-' . $signal->location2Id,
-            'parent-' . $signal->location2Id,
+            'path-' . $signal->location2Id,
             'location-' . $signal->parentLocation2Id,
             'parent-' . $signal->parentLocation2Id,
         ];

--- a/src/SignalSlot/UpdateLocationSlot.php
+++ b/src/SignalSlot/UpdateLocationSlot.php
@@ -12,8 +12,6 @@ use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
  * A slot handling UpdateLocationSignal.
- *
- * @todo Signal missing info on parent location, which is relevant if priority of location was updated.
  */
 class UpdateLocationSlot extends AbstractContentSlot
 {

--- a/tests/SignalSlot/CreateLocationSlotTest.php
+++ b/tests/SignalSlot/CreateLocationSlotTest.php
@@ -12,9 +12,12 @@ use eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal;
 
 class CreateLocationSlotTest extends AbstractContentSlotTest
 {
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
+
     public function createSignal()
     {
-        return new CreateLocationSignal(['contentId' => $this->contentId]);
+        return new CreateLocationSignal(['contentId' => $this->contentId, 'locationId' => $this->locationId, 'parentLocationId' => $this->parentLocationId]);
     }
 
     public function getSlotClass()
@@ -24,6 +27,6 @@ class CreateLocationSlotTest extends AbstractContentSlotTest
 
     public function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal'];
+        return [CreateLocationSignal::class];
     }
 }

--- a/tests/SignalSlot/MoveSubtreeSlotTest.php
+++ b/tests/SignalSlot/MoveSubtreeSlotTest.php
@@ -14,6 +14,7 @@ class MoveSubtreeSlotTest extends AbstractContentSlotTest
 {
     protected $locationId = 45;
     protected $parentLocationId = 43;
+    protected $oldParentLocationId = 2;
 
     public function createSignal()
     {
@@ -21,13 +22,14 @@ class MoveSubtreeSlotTest extends AbstractContentSlotTest
             [
                 'locationId' => $this->locationId,
                 'newParentLocationId' => $this->parentLocationId,
+                'oldParentLocationId' => $this->oldParentLocationId,
             ]
         );
     }
 
     public function generateTags()
     {
-        return ['path-' . $this->locationId, 'location-' . $this->parentLocationId, 'parent-' . $this->parentLocationId];
+        return ['path-' . $this->locationId, 'location-' . $this->oldParentLocationId, 'parent-' . $this->oldParentLocationId, 'location-' . $this->parentLocationId, 'parent-' . $this->parentLocationId];
     }
 
     public function getSlotClass()
@@ -37,6 +39,6 @@ class MoveSubtreeSlotTest extends AbstractContentSlotTest
 
     public function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal'];
+        return [MoveSubtreeSignal::class];
     }
 }

--- a/tests/SignalSlot/SwapLocationSlotTest.php
+++ b/tests/SignalSlot/SwapLocationSlotTest.php
@@ -12,23 +12,46 @@ use eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal;
 
 class SwapLocationSlotTest extends AbstractContentSlotTest
 {
-    public function setUp()
-    {
-        $this->markTestIncomplete('fixme');
-    }
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
+
+    protected $swapContentId = 62;
+    protected $swapLocationId = 65;
+    protected $swapParentLocationId = 63;
 
     public function createSignal()
     {
-        return new SwapLocationSignal(['content1Id' => $this->contentId]);
+        return new SwapLocationSignal([
+            'content1Id' => $this->contentId,
+            'location1Id' => $this->locationId,
+            'parentLocation1Id' => $this->parentLocationId,
+            'content2Id' => $this->swapContentId,
+            'location2Id' => $this->swapLocationId,
+            'parentLocation2Id' => $this->swapParentLocationId,
+        ]);
+    }
+
+    public function generateTags()
+    {
+        return [
+            'content-' . $this->contentId,
+            'path-' . $this->locationId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
+            'content-' . $this->swapContentId,
+            'path-' . $this->swapLocationId,
+            'location-' . $this->swapParentLocationId,
+            'parent-' . $this->swapParentLocationId,
+        ];
     }
 
     public function getSlotClass()
     {
-        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\SetContentStateSlot';
+        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\SwapLocationSlot';
     }
 
     public function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
+        return [SwapLocationSignal::class];
     }
 }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28326

Makes it possible to now expire parent location as well as sibling cache for
affected content.

Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2169


Todo:
- [x] Update tests once kernel part is in