### PR TITLE
Move UserContextSubscriber logic to ezplatform-http-cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
         - php: 7.1
           env: CHECK_CS=true
         # Functional
-        - php: 7.1
-          env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=1.13 SYMFONY_ENV=behat
+        - php: 5.6
+          env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=1.13 SYMFONY_ENV=behat PHP_IMAGE=ezsystems/php:5.6-v1
         - php: 7.1
           env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=master SYMFONY_ENV=behat
 

--- a/src/AppCache.php
+++ b/src/AppCache.php
@@ -92,7 +92,7 @@ class AppCache extends EventDispatchingHttpCache
     }
 
     /**
-     * Perform cleanup of reponse
+     * Perform cleanup of reponse.
      *
      * @param Response $response
      */

--- a/src/Proxy/UserContextSubscriber.php
+++ b/src/Proxy/UserContextSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * File containing the UserContextSubscriber class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Proxy;
+
+use FOS\HttpCache\SymfonyCache\UserContextSubscriber as BaseUserContextSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Extends UserContextSubscriber from FOSHttpCache to include original request.
+ *
+ * {@inheritdoc}
+ */
+class UserContextSubscriber extends BaseUserContextSubscriber
+{
+    protected function cleanupHashLookupRequest(Request $hashLookupRequest, Request $originalRequest)
+    {
+        parent::cleanupHashLookupRequest($hashLookupRequest, $originalRequest);
+        // Embed the original request as we need it to match the SiteAccess.
+        $hashLookupRequest->attributes->set('_ez_original_request', $originalRequest);
+    }
+}


### PR DESCRIPTION
Another thing needed for https://github.com/ezsystems/ezpublish-kernel/pull/2194

Look into if we could already reuse more of FosHttpCache here _(for instance it's getDefaultSubscribers Purge & Refresh Subscriber, as commented on inline here now)_, however that won't be possible before we move to FosHttpCache 2.x. 