### PR TITLE
EZP-28848: Enable using FOSHttpCache for tagging responses

### DIFF
--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -51,11 +51,37 @@ above. These can be found in `src/ResponseTagger`.
 
 For custom or eZ controllers _(like REST at the time of writing)_ still using `X-Location-Id`, a dedicated response
 listener `XLocationIdResponseSubscriber` handles translating this to tags so the cache can be properly invalidated by
-this bundle.
+this bundle. It supports comma separated location id values which was only partially supported in earlier versions.
 
-*This is currently marked as Deprecated, and for rendering content it is thus advice to refactor to use Content View.
-For other needs there is an internal tag handler in this bundle that can be used, however be aware it will probably
-change once we move to FOSHttpCache 2.x, so in this case staying with `X-Location-Id` for the time being is ok.*
+*NOTE: This is currently marked as Deprecated, and for rendering eZ content it is thus advice to refactor to use Content
+View. For other needs there is an FOS tag handler for Twig and PHP that can be used, see below for further info.*
+
+
+### For custom needs using FOSHttpCache (tagging relations and more)
+
+For custom needs, including template logic for eZ content relations which is here used for examples, there are two ways
+to tag your responses.
+
+##### Twig usage
+
+For twig usage, you can make sure response is tagged correctly by using the following twig operator in your template:
+```twig
+    {{ fos_httpcache_tag('relation-33') }}
+
+    {# Or using array for several values #}
+    {{ fos_httpcache_tag(['relation-33', 'relation-44']) }}
+```
+
+##### PHP Usage
+
+Fo PHP usage, FOSHttpCache exposes `fos_http_cache.handler.tag_handler` service which lets you add tags to a response:
+```php
+    /** @var \FOS\HttpCache\Handler\TagHandler $tagHandler */
+    $tagHandler->addTags(['relation-33', 'relation-44']);
+```
+
+*WARNING: Be aware service name and type hint will somewhat change once we move to FOSHttpCache 2.x, so in this case
+you can alternatively consider to add tag in twig template or stay with usage of `X-Location-Id` for the time being.*
 
 ## How purge tagging is done
 

--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -62,7 +62,7 @@ View. For other needs there is an FOS tag handler for Twig and PHP that can be u
 For custom needs, including template logic for eZ content relations which is here used for examples, there are two ways
 to tag your responses.
 
-##### Twig usage
+##### Twig use
 
 For twig usage, you can make sure response is tagged correctly by using the following twig operator in your template:
 ```twig
@@ -72,13 +72,17 @@ For twig usage, you can make sure response is tagged correctly by using the foll
     {{ fos_httpcache_tag(['relation-33', 'relation-44']) }}
 ```
 
-##### PHP Usage
+See: http://foshttpcachebundle.readthedocs.io/en/1.3/features/tagging.html#tagging-from-twig-templates
+
+##### PHP use
 
 Fo PHP usage, FOSHttpCache exposes `fos_http_cache.handler.tag_handler` service which lets you add tags to a response:
 ```php
     /** @var \FOS\HttpCache\Handler\TagHandler $tagHandler */
     $tagHandler->addTags(['relation-33', 'relation-44']);
 ```
+
+See: http://foshttpcachebundle.readthedocs.io/en/1.3/features/tagging.html#tagging-from-code
 
 *WARNING: Be aware service name and type hint will somewhat change once we move to FOSHttpCache 2.x, so in this case
 you can alternatively consider to add tag in twig template or stay with usage of `X-Location-Id` for the time being.*

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -39,6 +39,10 @@ class TagHandler extends FOSTagHandler implements TagHandlerInterface
 
     public function tagResponse(Response $response, $replace = false)
     {
+        if ($this->hasTags()) {
+            $this->addTagHeaders($response, explode(',', $this->getTagsHeaderValue()));
+        }
+
         return $this;
     }
 

--- a/src/Resources/config/fos_http_cache.yml
+++ b/src/Resources/config/fos_http_cache.yml
@@ -10,8 +10,5 @@ user_context:
 
 tags:
     # Configure tag header for FosHttpCache
-    # WARNING: Please don't use the TagHandler from FOS yet in generic reusable code:
-    # 1. Until 2.x it is hardcoded to use comma separated list of tags, which won't work on Fastly and
-    #    will conflict with the one header per key format we currently use with xkey (as per their doc)
-    # 2. In FosHttpCache 1.x it is only available if proxy client is configured as "varnish" or "custom"
+    # See docs/using_tags.md for further info on usage
     header: '%ezplatform.http_cache.tags.header%'

--- a/src/ResponseConfigurator/ResponseCacheConfigurator.php
+++ b/src/ResponseConfigurator/ResponseCacheConfigurator.php
@@ -33,6 +33,8 @@ interface ResponseCacheConfigurator
     /**
      * Adds $tags to the response's cache tags header.
      *
+     * @todo Change to call addTags(), do separate call for writing them to response to avoid serialization on each call.
+     *
      * @param \Symfony\Component\HttpFoundation\Response $response
      * @param string|array $tags Single tag, or array of tags
      *


### PR DESCRIPTION
Enable usage of [fos_httpcache_tag()](http://foshttpcachebundle.readthedocs.io/en/1.3/features/tagging.html#tagging-from-twig-templates) and FOS TagHandler in order to be able to solve tagging relations which is template logic, added doc on how.

Todo:
- [x] Manually test usage of fos_httpcache_tag()

Followup:
- PR on overloading template output to tag responses _(as kernel is meant to know nothing of http cache)_