### PR TITLE
EZP-28760: Change to use space seperated header

### DIFF
--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -44,6 +44,15 @@ class TagHandler extends FOSTagHandler implements TagHandlerInterface
 
     public function addTagHeaders(Response $response, array $tags)
     {
-        $response->headers->set($this->tagsHeader, $tags, false);
+        if ($response->headers->has($this->tagsHeader)) {
+            // Get as array and handle both array based and string based values
+            $headerValue = $response->headers->get($this->tagsHeader, null, false);
+            $tags = array_merge(
+                $tags,
+                count($headerValue) === 1 ? explode(' ', $headerValue[0]) : $headerValue
+            );
+        }
+
+        $response->headers->set($this->tagsHeader, implode(' ', array_unique($tags)));
     }
 }

--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -73,8 +73,12 @@ class TagAwareStore extends Store implements RequestAwarePurger
         $digest = $response->headers->get('X-Content-Digest');
         $tags = $response->headers->get('xkey', null, false);
 
-        // Handle both array based and string based header (her gotten as single item array with space separated string)
-        foreach (array_unique(count($tags) === 1 ? explode(' ', $tags[0]) : $tags) as $tag) {
+        if (count($tags) === 1) {
+            // Handle string based header (her gotten as single item array with space separated string)
+            $tags = explode(' ', $tags[0]);
+        }
+
+        foreach (array_unique($tags) as $tag) {
             if (false === $this->saveTag($tag, $digest)) {
                 throw new \RuntimeException('Unable to store the cache tag meta information.');
             }

--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -69,11 +69,12 @@ class TagAwareStore extends Store implements RequestAwarePurger
     {
         $key = parent::write($request, $response);
 
-        // Now save tags
+        // Get tags in order to save them
         $digest = $response->headers->get('X-Content-Digest');
         $tags = $response->headers->get('xkey', null, false);
 
-        foreach (array_unique($tags) as $tag) {
+        // Handle both array based and string based header (her gotten as single item array with space separated string)
+        foreach (array_unique(count($tags) === 1 ? explode(' ', $tags[0]) : $tags) as $tag) {
             if (false === $this->saveTag($tag, $digest)) {
                 throw new \RuntimeException('Unable to store the cache tag meta information.');
             }


### PR DESCRIPTION
> [EZP-28760](https://jira.ez.no/browse/EZP-28760) Varnish xkey header using wrong separator

Header seems to be transformed to comma separated values per [rfc2616](https://tools.ietf.org/html/rfc2616#section-4.2)
by potentially Apache &/or others _(not seen this happen on nginx)_.

As Varnish xkey now has doc stating space separated header is supported,
change to rather use that to stay on the safe side of this.