### PR TITLE
EZP-28580: HTTP Cache purge when URLService\UpdateURLSignal is emitted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.7.7@dev || ^6.12.1@dev || ^7.0@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.2@dev || ^7.1@dev",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "symfony/symfony": "^2.7 | ^3.1"
     },

--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -148,6 +148,14 @@ services:
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\RemoveTranslationSignal }
 
+    ezplatform.http_cache.signalslot.update_url:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\UpdateUrlSlot
+        parent: ezplatform.http_cache.signalslot.abstract_content
+        arguments:
+            - "@ezpublish.spi.persistence.cache.urlHandler"
+        tags:
+            - { name: ezpublish.api.slot, signal: URLService\UpdateUrlSignal }
+
     # Content Type
     ezplatform.http_cache.signalslot.publish_content_type:
         class: EzSystems\PlatformHttpCacheBundle\SignalSlot\PublishContentTypeSlot

--- a/src/SignalSlot/UpdateUrlSlot.php
+++ b/src/SignalSlot/UpdateUrlSlot.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\SPI\Persistence\URL\Handler as UrlHandler;
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
+
+/**
+ * A slot handling UpdateUrlSignal.
+ */
+class UpdateUrlSlot extends AbstractContentSlot
+{
+    /** @var \eZ\Publish\SPI\Persistence\URL\Handler */
+    private $urlHandler;
+
+    /**
+     * UpdateUrlSlot constructor.
+     *
+     * @param PurgeClientInterface $purgeClient
+     * @param UrlHandler $urlHandler
+     */
+    public function __construct(PurgeClientInterface $purgeClient, UrlHandler $urlHandler)
+    {
+        parent::__construct($purgeClient);
+
+        $this->urlHandler = $urlHandler;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\URLService\UpdateUrlSignal $signal
+     */
+    public function generateTags(Signal $signal)
+    {
+        if ($signal->urlChanged) {
+            return array_map(function($contentId) {
+                return 'content-' . $contentId;
+            }, $this->urlHandler->findUsages($signal->urlId));
+        }
+
+        return [];
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\URLService\UpdateUrlSignal;
+    }
+}

--- a/tests/SignalSlot/UpdateUrlSlotTest.php
+++ b/tests/SignalSlot/UpdateUrlSlotTest.php
@@ -23,6 +23,16 @@ class UpdateUrlSlotTest extends AbstractSlotTest
     /** @var \eZ\Publish\SPI\Persistence\URL\Handler|\PHPUnit_Framework_MockObject_MockObject */
     private $spiUrlHandlerMock = null;
 
+    /**
+     * Check if required signal exists due to BC.
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists(UpdateUrlSignal::class)) {
+            self::markTestSkipped('UpdateUrlSignal does not exist');
+        }
+    }
+
     protected function createSlot()
     {
         $class = $this->getSlotClass();

--- a/tests/SignalSlot/UpdateUrlSlotTest.php
+++ b/tests/SignalSlot/UpdateUrlSlotTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\URLService\UpdateUrlSignal;
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\UpdateUrlSlot;
+use eZ\Publish\SPI\Persistence\URL\Handler;
+
+class UpdateUrlSlotTest extends AbstractSlotTest
+{
+    const URL_ID = 63;
+
+    const CONTENT_IDS = [
+       2, 3, 5, 7, 11
+    ];
+
+    /** @var \eZ\Publish\SPI\Persistence\URL\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    private $spiUrlHandlerMock = null;
+
+    protected function createSlot()
+    {
+        $class = $this->getSlotClass();
+        if ($this->spiUrlHandlerMock === null) {
+            $this->spiUrlHandlerMock = $this->createMock(Handler::class);
+            $this->spiUrlHandlerMock
+                ->expects($this->any())
+                ->method('findUsages')
+                ->with(self::URL_ID)
+                ->willReturn(self::CONTENT_IDS);
+        }
+
+        return new $class($this->purgeClientMock, $this->spiUrlHandlerMock);
+    }
+
+    public function createSignal()
+    {
+        return new UpdateUrlSignal([
+            'urlId' => self::URL_ID,
+            'urlChanged' => true
+        ]);
+    }
+
+    public function generateTags()
+    {
+        return array_map(function($id) {
+            return 'content-' . $id;
+        }, self::CONTENT_IDS);
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return [
+            UpdateUrlSignal::class
+        ];
+    }
+
+    public function getSlotClass()
+    {
+        return UpdateUrlSlot::class;
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28585
> Requires: https://github.com/ezsystems/ezpublish-kernel/pull/2259

## Description 

Implementation of HTTP cache purge when `URLService\UpdateURLSignal` is emitted. Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2259

## TODO: 
- [x] Raise the `ezpublish-kernel` requirement when  https://github.com/ezsystems/ezpublish-kernel/pull/2259 will be merged 