### PR TITLE
[0.4] Ajust composer and travis prior to 2.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - php: 5.6
           env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=1.13 SYMFONY_ENV=behat PHP_IMAGE=ezsystems/php:5.6-v1
         - php: 7.1
-          env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=master SYMFONY_ENV=behat
+          env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=2.0 SYMFONY_ENV=behat
 
 # test only master (+ Pull requests)
 branches:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.7.7@dev || ^6.12.1@dev || ^7.0@dev",
+        "ezsystems/ezpublish-kernel": "~6.7.7@dev || ^6.12.1@dev || ~7.0.0@dev",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "symfony/symfony": "^2.7 | ^3.1"
     },


### PR DESCRIPTION
0.4 does not work on 2.1 as the changes for that is part of 0.5, so
adjusts both composer and travis to reflect that.

Side: This might fail for unrelated reason on PHP 5.6 with 1.13, if
so then we know for sure #58 is not causing it's failues.