### PR TITLE
[Varnish] Use PURGE for purgeAll()

### DIFF
--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -50,6 +50,9 @@ class VarnishPurgeClient implements PurgeClientInterface
 
     public function purgeAll()
     {
-        $this->cacheManager->invalidate(['key' => 'ez-all']);
+        $this->cacheManager->invalidatePath(
+            '/',
+            ['key' => 'ez-all', 'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME']]
+        );
     }
 }

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -89,8 +89,8 @@ class VarnishPurgeClientTest extends TestCase
     {
         $this->cacheManager
             ->expects($this->once())
-            ->method('invalidate')
-            ->with(array('key' => 'ez-all'));
+            ->method('invalidatePath')
+            ->with('/', ['key' => 'ez-all', 'Host' => 'localhost']);
 
         $this->purgeClient->purgeAll();
     }


### PR DESCRIPTION
Found when reviewing code for another issue atm, now that purgeAll() is
supposed to work by invalidating a tag, it should use PURGE _(using
invalidatePath() like code above)_, and not BAN _(as used by invalidate())_.