### PR TITLE
EZP-29297: 404 error pages for hidden locations should be tagged

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.13.2@dev || ^7.1@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.2@dev",
         "friendsofsymfony/http-cache-bundle": "^1.3.13",
         "symfony/symfony": "^2.7 | ^3.1"
     },

--- a/spec/EventSubscriber/HiddenLocationExceptionSubscriberSpec.php
+++ b/spec/EventSubscriber/HiddenLocationExceptionSubscriberSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace spec\EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Exception\HiddenLocationException;
+use Prophecy\Argument;
+
+class HiddenLocationExceptionSubscriberSpec extends ObjectBehavior
+{
+    public function let(
+        LocationTagger $locationTagger,
+        ContentInfoTagger $contentInfoTagger
+    ) {
+        $this->beConstructedWith($locationTagger, $contentInfoTagger);
+    }
+
+    public function it_tags_on_hidden_location_exception(
+        GetResponseForExceptionEvent $event,
+        LocationTagger $locationTagger,
+        ContentInfoTagger $contentInfoTagger,
+        Location $location,
+        ContentInfo $contentInfo,
+        HiddenLocationException $exception
+    ) {
+        $event->getException()->willReturn($exception);
+        $exception->getLocation()->willReturn($location);
+        $location->getContentInfo()->willReturn($contentInfo);
+        $locationTagger->tag($location)->willReturn($locationTagger);
+        $contentInfoTagger->tag($contentInfo)->willReturn($contentInfoTagger);
+
+        $this->tagHiddenLocationExceptionResponse($event);
+
+        $event->getException()->shouldHaveBeenCalled();
+        $exception->getLocation()->shouldHaveBeenCalled();
+        $locationTagger->tag(Argument::type(Location::class))->shouldHaveBeenCalled();
+        $contentInfoTagger->tag(Argument::type(ContentInfo::class))->shouldHaveBeenCalled();
+    }
+
+    public function it_does_not_tag_on_other_exceptions(
+        GetResponseForExceptionEvent $event,
+        LocationTagger $locationTagger,
+        ContentInfoTagger $contentInfoTagger,
+        \Exception $exception
+    ) {
+        $event->getException()->willReturn($exception);
+
+        $locationTagger->tag(Argument::type(Location::class))->shouldNotBeCalled();
+        $contentInfoTagger->tag(Argument::type(ContentInfo::class))->shouldNotBeCalled();
+
+        $this->tagHiddenLocationExceptionResponse($event);
+    }
+}

--- a/src/EventSubscriber/HiddenLocationExceptionSubscriber.php
+++ b/src/EventSubscriber/HiddenLocationExceptionSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Exception\HiddenLocationException;
+use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
+use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
+     */
+    private $responseTagger;
+
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator
+     */
+    private $responseConfigurator;
+
+    /**
+     * @var \Symfony\Bundle\TwigBundle\Controller\ExceptionController
+     */
+    private $exceptionController;
+
+    public function __construct(ResponseCacheConfigurator $responseConfigurator, LocationTagger $responseTagger, ExceptionController $exceptionController)
+    {
+        $this->responseTagger = $responseTagger;
+        $this->responseConfigurator = $responseConfigurator;
+        $this->exceptionController = $exceptionController;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::EXCEPTION => ['tagHiddenLocationExceptionResponse', 10]];
+    }
+
+    public function tagHiddenLocationExceptionResponse(GetResponseForExceptionEvent $event)
+    {
+        if (!$event->getException() instanceof HiddenLocationException) {
+            return;
+        }
+
+        /** @var HiddenLocationException $exception */
+        $exception = $event->getException();
+
+        $response = $this->exceptionController->showAction($event->getRequest(), FlattenException::create($exception));
+        $this->responseTagger->tag($this->responseConfigurator, $response, $exception->getLocation());
+
+        $event->setResponse($response);
+    }
+}

--- a/src/EventSubscriber/HiddenLocationExceptionSubscriber.php
+++ b/src/EventSubscriber/HiddenLocationExceptionSubscriber.php
@@ -7,10 +7,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
 
 use eZ\Publish\Core\MVC\Exception\HiddenLocationException;
-use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator;
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
-use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -20,23 +17,11 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
     /**
      * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
      */
-    private $responseTagger;
+    private $locationTagger;
 
-    /**
-     * @var \EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator
-     */
-    private $responseConfigurator;
-
-    /**
-     * @var \Symfony\Bundle\TwigBundle\Controller\ExceptionController
-     */
-    private $exceptionController;
-
-    public function __construct(ResponseCacheConfigurator $responseConfigurator, LocationTagger $responseTagger, ExceptionController $exceptionController)
+    public function __construct(LocationTagger $locationTagger)
     {
-        $this->responseTagger = $responseTagger;
-        $this->responseConfigurator = $responseConfigurator;
-        $this->exceptionController = $exceptionController;
+        $this->locationTagger = $locationTagger;
     }
 
     public static function getSubscribedEvents()
@@ -52,10 +37,6 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
 
         /** @var HiddenLocationException $exception */
         $exception = $event->getException();
-
-        $response = $this->exceptionController->showAction($event->getRequest(), FlattenException::create($exception));
-        $this->responseTagger->tag($this->responseConfigurator, $response, $exception->getLocation());
-
-        $event->setResponse($response);
+        $this->locationTagger->tag($exception->getLocation());
     }
 }

--- a/src/EventSubscriber/HiddenLocationExceptionSubscriber.php
+++ b/src/EventSubscriber/HiddenLocationExceptionSubscriber.php
@@ -7,6 +7,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
 
 use eZ\Publish\Core\MVC\Exception\HiddenLocationException;
+use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger;
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -19,9 +20,15 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
      */
     private $locationTagger;
 
-    public function __construct(LocationTagger $locationTagger)
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger
+     */
+    private $contentInfoTagger;
+
+    public function __construct(LocationTagger $locationTagger, ContentInfoTagger $contentInfoTagger)
     {
         $this->locationTagger = $locationTagger;
+        $this->contentInfoTagger = $contentInfoTagger;
     }
 
     public static function getSubscribedEvents()
@@ -35,8 +42,9 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var HiddenLocationException $exception */
-        $exception = $event->getException();
-        $this->locationTagger->tag($exception->getLocation());
+        /** @var \eZ\Publish\API\Repository\Values\Content\Location $location */
+        $location = $event->getException()->getLocation();
+        $this->locationTagger->tag($location);
+        $this->contentInfoTagger->tag($location->getContentInfo());
     }
 }

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -28,7 +28,7 @@ services:
 
     ezplatform.hidden_location.exception_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\HiddenLocationExceptionSubscriber
-        arguments: ['@ezplatform.view_cache.response_tagger.location']
+        arguments: ['@ezplatform.view_cache.response_tagger.location', '@ezplatform.view_cache.response_tagger.content_info']
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -26,6 +26,12 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezplatform.hidden_location.exception_subscriber:
+        class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\HiddenLocationExceptionSubscriber
+        arguments: ['@ezplatform.view_cache.response_configurator', '@ezplatform.view_cache.response_tagger.location', '@twig.controller.exception']
+        tags:
+            - { name: kernel.event_subscriber }
+
     # ResponseConfigurator
     ezplatform.view_cache.response_configurator:
         class: EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -28,7 +28,7 @@ services:
 
     ezplatform.hidden_location.exception_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\HiddenLocationExceptionSubscriber
-        arguments: ['@ezplatform.view_cache.response_configurator', '@ezplatform.view_cache.response_tagger.location', '@twig.controller.exception']
+        arguments: ['@ezplatform.view_cache.response_tagger.location']
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29297](https://jira.ez.no/browse/EZP-29297)
| **Bug**| yes
| **New feature**    | no
| **Target version** | master (`0.7`)
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

These changes are related to: https://github.com/ezsystems/ezpublish-kernel/pull/2350