### PR TITLE
Missing tagger refactoring in HttpCacheResponseSubscriber

### DIFF
--- a/spec/EventSubscriber/HttpCacheResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/HttpCacheResponseSubscriberSpec.php
@@ -72,6 +72,6 @@ class HttpCacheResponseSubscriberSpec extends ObjectBehavior
 
         $configurator->enableCache(Argument::type(Response::class))->shouldHaveBeenCalled();
         $configurator->setSharedMaxAge(Argument::type(Response::class))->shouldHaveBeenCalled();
-        $dispatcherTagger->tag($configurator, Argument::type(Response::class), $view)->shouldHaveBeenCalled();
+        $dispatcherTagger->tag($view)->shouldHaveBeenCalled();
     }
 }

--- a/src/EventSubscriber/HttpCacheResponseSubscriber.php
+++ b/src/EventSubscriber/HttpCacheResponseSubscriber.php
@@ -47,7 +47,7 @@ class HttpCacheResponseSubscriber implements EventSubscriberInterface
         $response = $event->getResponse();
         $this->responseConfigurator->enableCache($response);
         $this->responseConfigurator->setSharedMaxAge($response);
-        $this->dispatcherTagger->tag($this->responseConfigurator, $response, $view);
+        $this->dispatcherTagger->tag($view);
 
         // NB!: FOSHTTPCacheBundle is taking care about writing the tags in own tag handler happening with priority 0
     }


### PR DESCRIPTION
This PR contain missing piece of changes introduced in https://github.com/ezsystems/ezplatform-http-cache/pull/70.