### PR TITLE
EZP-29817: Varnish - Purge requests with tokens

### DIFF
--- a/docs/varnish/vcl/parameters.vcl
+++ b/docs/varnish/vcl/parameters.vcl
@@ -10,6 +10,11 @@ backend ezplatform {
 }
 
 // ACL for invalidators IP
+//
+// Alternative using ACL_INVALIDATE_TOKEN : VCL code also allows for token based invalidation, to use it define a
+//      shared secret using env variable ACL_INVALIDATE_TOKEN and eZ Platform will also use that for configuring this
+//      bundle. This is prefered for setups such as platform.sh/eZ Platform Cloud, where circular service dependency is
+//      unwanted. If you use this, use a strong cryptological secure hash & make sure to keep the token secret.
 acl invalidators {
     "127.0.0.1";
     "192.168.0.0"/16;

--- a/docs/varnish/vcl/parameters.vcl
+++ b/docs/varnish/vcl/parameters.vcl
@@ -15,7 +15,7 @@ backend ezplatform {
 //      shared secret using env variable ACL_INVALIDATE_TOKEN and eZ Platform will also use that for configuring this
 //      bundle. This is prefered for setups such as platform.sh/eZ Platform Cloud, where circular service dependency is
 //      unwanted. If you use this, use a strong cryptological secure hash & make sure to keep the token secret.
-// Use ez_purge_acl (see varnish4.vcl Alternative 1 or Alternative 2) for invalidation by token, depends on your Varnish version.
+// Use ez_purge_acl (see ez_purge_acl comment in varnish4.vcl) for invalidation by token, depends on your Varnish version.
 acl invalidators {
     "127.0.0.1";
     "192.168.0.0"/16;

--- a/docs/varnish/vcl/parameters.vcl
+++ b/docs/varnish/vcl/parameters.vcl
@@ -11,8 +11,8 @@ backend ezplatform {
 
 // ACL for invalidators IP
 //
-// Alternative using ACL_INVALIDATE_TOKEN : VCL code also allows for token based invalidation, to use it define a
-//      shared secret using env variable ACL_INVALIDATE_TOKEN and eZ Platform will also use that for configuring this
+// Alternative using HTTPCACHE_VARNISH_INVALIDATE_TOKEN : VCL code also allows for token based invalidation, to use it define a
+//      shared secret using env variable HTTPCACHE_VARNISH_INVALIDATE_TOKEN and eZ Platform will also use that for configuring this
 //      bundle. This is prefered for setups such as platform.sh/eZ Platform Cloud, where circular service dependency is
 //      unwanted. If you use this, use a strong cryptological secure hash & make sure to keep the token secret.
 // Use ez_purge_acl (see ez_purge_acl comment in varnish4.vcl) for invalidation by token, depends on your Varnish version.

--- a/docs/varnish/vcl/parameters.vcl
+++ b/docs/varnish/vcl/parameters.vcl
@@ -15,6 +15,7 @@ backend ezplatform {
 //      shared secret using env variable ACL_INVALIDATE_TOKEN and eZ Platform will also use that for configuring this
 //      bundle. This is prefered for setups such as platform.sh/eZ Platform Cloud, where circular service dependency is
 //      unwanted. If you use this, use a strong cryptological secure hash & make sure to keep the token secret.
+// Use ez_purge_acl (see varnish4.vcl Alternative 1 or Alternative 2) for invalidation by token, depends on your Varnish version.
 acl invalidators {
     "127.0.0.1";
     "192.168.0.0"/16;

--- a/docs/varnish/vcl/varnish4.vcl
+++ b/docs/varnish/vcl/varnish4.vcl
@@ -164,17 +164,33 @@ sub ez_purge {
 }
 
 sub ez_purge_acl {
-    if (req.http.x-purge-token) {
-        # Use the line above instead of  line with 'std.getenv' if your Varnish version is lower than 6.2 and doesn't support std.getenv,
-        # change the token "_YOUR_TOKEN_HERE_" before enabling it.
-        # if (req.http.x-purge-token != "_YOUR_TOKEN_HERE_") {
-        if (req.http.x-purge-token != std.getenv("ACL_INVALIDATE_TOKEN")) {
-            return (synth(405, "Method not allowed"));
-        }
-    } else if  (!client.ip ~ invalidators) {
+    if  (!client.ip ~ invalidators) {
         return (synth(405, "Method not allowed"));
     }
 }
+
+## Alternative 1: ez_purge_acl for purging by Token (Varnish >= 5.1, std.getenv support)
+#sub ez_purge_acl {
+#    if (req.http.x-purge-token) {
+#        if (req.http.x-purge-token != std.getenv("ACL_INVALIDATE_TOKEN")) {
+#            return (synth(405, "Method not allowed"));
+#        }
+#    } else if  (!client.ip ~ invalidators) {
+#        return (synth(405, "Method not allowed"));
+#    }
+#}
+
+## Alternative 2: ez_purge_acl for purging by Token (Varnish <= 5.1, token value in vcl)
+#sub ez_purge_acl {
+#    if (req.http.x-purge-token) {
+#        # change the token "_YOUR_TOKEN_HERE_" before enabling it.
+#        if (req.http.x-purge-token != "_YOUR_TOKEN_HERE_") {
+#            return (synth(405, "Method not allowed"));
+#        }
+#    } else if  (!client.ip ~ invalidators) {
+#        return (synth(405, "Method not allowed"));
+#    }
+#}
 
 // Sub-routine to get client user context hash, used to for being able to vary page cache on user rights.
 sub ez_user_context_hash {

--- a/docs/varnish/vcl/varnish4.vcl
+++ b/docs/varnish/vcl/varnish4.vcl
@@ -164,33 +164,16 @@ sub ez_purge {
 }
 
 sub ez_purge_acl {
+//    if (req.http.x-purge-token) {
+//        #  Won't work on Varnish <= 5.1, if needed you can hardcode a secret token here instead of std.getenv() usage
+//        if (req.http.x-purge-token != std.getenv("ACL_INVALIDATE_TOKEN")) {
+//            return (synth(405, "Method not allowed"));
+//        }
+//    } else if  (!client.ip ~ invalidators) {
     if  (!client.ip ~ invalidators) {
         return (synth(405, "Method not allowed"));
     }
 }
-
-## Alternative 1: ez_purge_acl for purging by Token (Varnish >= 5.1, std.getenv support)
-#sub ez_purge_acl {
-#    if (req.http.x-purge-token) {
-#        if (req.http.x-purge-token != std.getenv("ACL_INVALIDATE_TOKEN")) {
-#            return (synth(405, "Method not allowed"));
-#        }
-#    } else if  (!client.ip ~ invalidators) {
-#        return (synth(405, "Method not allowed"));
-#    }
-#}
-
-## Alternative 2: ez_purge_acl for purging by Token (Varnish <= 5.1, token value in vcl)
-#sub ez_purge_acl {
-#    if (req.http.x-purge-token) {
-#        # change the token "_YOUR_TOKEN_HERE_" before enabling it.
-#        if (req.http.x-purge-token != "_YOUR_TOKEN_HERE_") {
-#            return (synth(405, "Method not allowed"));
-#        }
-#    } else if  (!client.ip ~ invalidators) {
-#        return (synth(405, "Method not allowed"));
-#    }
-#}
 
 // Sub-routine to get client user context hash, used to for being able to vary page cache on user rights.
 sub ez_user_context_hash {

--- a/docs/varnish/vcl/varnish4.vcl
+++ b/docs/varnish/vcl/varnish4.vcl
@@ -165,7 +165,7 @@ sub ez_purge {
 
 sub ez_purge_acl {
 //    if (req.http.x-purge-token) {
-//        #  Won't work on Varnish <= 5.1, if needed you can hardcode a secret token here instead of std.getenv() usage
+//        #  Won't work on Varnish <= 5.1, if needed in 4.1 you can hardcode a secret token here instead of std.getenv() usage
 //        if (req.http.x-purge-token != std.getenv("ACL_INVALIDATE_TOKEN")) {
 //            return (synth(405, "Method not allowed"));
 //        }

--- a/docs/varnish/vcl/varnish4.vcl
+++ b/docs/varnish/vcl/varnish4.vcl
@@ -166,7 +166,7 @@ sub ez_purge {
 sub ez_purge_acl {
 //    if (req.http.x-purge-token) {
 //        #  Won't work on Varnish <= 5.1, if needed in 4.1 you can hardcode a secret token here instead of std.getenv() usage
-//        if (req.http.x-purge-token != std.getenv("ACL_INVALIDATE_TOKEN")) {
+//        if (req.http.x-purge-token != std.getenv("HTTPCACHE_VARNISH_INVALIDATE_TOKEN")) {
 //            return (synth(405, "Method not allowed"));
 //        }
 //    } else if  (!client.ip ~ invalidators) {

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -34,12 +34,12 @@ class HttpCacheConfigParser implements ParserInterface
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()
                     ->end()
-                    ->scalarNode('purge_auth_header')
-                        ->info('Header name for authenticated purge')
-                        ->defaultValue('X-PURGE-AUTH')
+                    ->scalarNode('varnish_invalidate_token_name')
+                        ->info('Optional: Varnish Invalidation token name for purge')
+                        ->defaultValue('x-purge-token')
                     ->end()
-                    ->scalarNode('purge_auth_key')
-                        ->info('Purge authentication key')
+                    ->scalarNode('varnish_invalidate_token')
+                        ->info('Optional: Varnish Invalidation token for purge')
                         ->defaultNull()
                     ->end();
 
@@ -60,12 +60,12 @@ class HttpCacheConfigParser implements ParserInterface
             $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
         }
 
-        if (isset($scopeSettings['http_cache']['purge_auth_header'])) {
-            $contextualizer->setContextualParameter('http_cache.purge_auth_header', $currentScope, $scopeSettings['http_cache']['purge_auth_header']);
+        if (isset($scopeSettings['http_cache']['varnish_invalidate_token_name'])) {
+            $contextualizer->setContextualParameter('http_cache.varnish_invalidate_token_name', $currentScope, $scopeSettings['http_cache']['varnish_invalidate_token_name']);
         }
 
-        if (isset($scopeSettings['http_cache']['purge_auth_key'])) {
-            $contextualizer->setContextualParameter('http_cache.purge_auth_key', $currentScope, $scopeSettings['http_cache']['purge_auth_key']);
+        if (isset($scopeSettings['http_cache']['varnish_invalidate_token'])) {
+            $contextualizer->setContextualParameter('http_cache.varnish_invalidate_token', $currentScope, $scopeSettings['http_cache']['varnish_invalidate_token']);
         }
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -34,10 +34,6 @@ class HttpCacheConfigParser implements ParserInterface
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()
                     ->end()
-                    ->scalarNode('varnish_invalidate_token_name')
-                        ->info('Optional: Varnish Invalidation token name for purge')
-                        ->defaultValue('x-purge-token')
-                    ->end()
                     ->scalarNode('varnish_invalidate_token')
                         ->info('Optional: Varnish Invalidation token for purge')
                         ->defaultNull()
@@ -58,10 +54,6 @@ class HttpCacheConfigParser implements ParserInterface
 
         if (isset($scopeSettings['http_cache']['purge_servers'])) {
             $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
-        }
-
-        if (isset($scopeSettings['http_cache']['varnish_invalidate_token_name'])) {
-            $contextualizer->setContextualParameter('http_cache.varnish_invalidate_token_name', $currentScope, $scopeSettings['http_cache']['varnish_invalidate_token_name']);
         }
 
         if (isset($scopeSettings['http_cache']['varnish_invalidate_token'])) {

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -33,6 +33,14 @@ class HttpCacheConfigParser implements ParserInterface
                         ->example(array('http://localhost/', 'http://another.server/'))
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()
+                    ->end()
+                    ->scalarNode('purge_auth_header')
+                        ->info('Header name for authenticated purge')
+                        ->defaultValue('X-PURGE-AUTH')
+                    ->end()
+                    ->scalarNode('purge_auth_key')
+                        ->info('Purge authentication key')
+                        ->defaultNull()
                     ->end();
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
@@ -50,6 +58,14 @@ class HttpCacheConfigParser implements ParserInterface
 
         if (isset($scopeSettings['http_cache']['purge_servers'])) {
             $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
+        }
+
+        if (isset($scopeSettings['http_cache']['purge_auth_header'])) {
+            $contextualizer->setContextualParameter('http_cache.purge_auth_header', $currentScope, $scopeSettings['http_cache']['purge_auth_header']);
+        }
+
+        if (isset($scopeSettings['http_cache']['purge_auth_key'])) {
+            $contextualizer->setContextualParameter('http_cache.purge_auth_key', $currentScope, $scopeSettings['http_cache']['purge_auth_key']);
         }
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
  */
 class VarnishPurgeClient implements PurgeClientInterface
 {
-    const INVALIDATE_TOKEN_NAME_PARAM = 'http_cache.varnish_invalidate_token_name';
     const INVALIDATE_TOKEN_PARAM = 'http_cache.varnish_invalidate_token';
 
     /**
@@ -88,12 +87,10 @@ class VarnishPurgeClient implements PurgeClientInterface
      */
     private function addPurgeAuthHeader(array $headers)
     {
-        if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_NAME_PARAM)
-            && $this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)
-            && null !== ($tokenName = $this->configResolver->getParameter(self::INVALIDATE_TOKEN_NAME_PARAM))
+        if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)
             && null !== ($token = $this->configResolver->getParameter(self::INVALIDATE_TOKEN_PARAM))
         ) {
-            $headers[$tokenName] = $token;
+            $headers['x-purge-token'] = $token;
         }
 
         return $headers;

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -14,8 +14,8 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
  */
 class VarnishPurgeClient implements PurgeClientInterface
 {
-    const PURGE_AUTH_HEADER_PARAM = 'http_cache.purge_auth_header';
-    const PURGE_AUTH_KEY_PARAM = 'http_cache.purge_auth_key';
+    const INVALIDATE_TOKEN_NAME_PARAM = 'http_cache.varnish_invalidate_token_name';
+    const INVALIDATE_TOKEN_PARAM = 'http_cache.varnish_invalidate_token';
 
     /**
      * @var \FOS\HttpCacheBundle\CacheManager
@@ -88,12 +88,12 @@ class VarnishPurgeClient implements PurgeClientInterface
      */
     private function addPurgeAuthHeader(array $headers)
     {
-        if ($this->configResolver->hasParameter(self::PURGE_AUTH_HEADER_PARAM)
-            && $this->configResolver->hasParameter(self::PURGE_AUTH_KEY_PARAM)
-            && null !== ($authHeader = $this->configResolver->getParameter(self::PURGE_AUTH_HEADER_PARAM))
-            && null !== ($authKey = $this->configResolver->getParameter(self::PURGE_AUTH_KEY_PARAM))
+        if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_NAME_PARAM)
+            && $this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)
+            && null !== ($tokenName = $this->configResolver->getParameter(self::INVALIDATE_TOKEN_NAME_PARAM))
+            && null !== ($token = $this->configResolver->getParameter(self::INVALIDATE_TOKEN_PARAM))
         ) {
-            $headers[$authHeader] = $authKey;
+            $headers[$tokenName] = $token;
         }
 
         return $headers;

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -15,6 +15,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 class VarnishPurgeClient implements PurgeClientInterface
 {
     const INVALIDATE_TOKEN_PARAM = 'http_cache.varnish_invalidate_token';
+    const INVALIDATE_TOKEN_PARAM_NAME = 'x-purge-token';
 
     /**
      * @var \FOS\HttpCacheBundle\CacheManager
@@ -90,7 +91,7 @@ class VarnishPurgeClient implements PurgeClientInterface
         if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)
             && null !== ($token = $this->configResolver->getParameter(self::INVALIDATE_TOKEN_PARAM))
         ) {
-            $headers['x-purge-token'] = $token;
+            $headers[self::INVALIDATE_TOKEN_PARAM_NAME] = $token;
         }
 
         return $headers;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,7 +19,9 @@ services:
 
     ezplatform.http_cache.purge_client.varnish:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishPurgeClient
-        arguments: ['@ezplatform.http_cache.cache_manager']
+        arguments:
+            - '@ezplatform.http_cache.cache_manager'
+            - '@ezpublish.config.resolver'
         tags:
             - {name: ezplatform.http_cache.purge_client, purge_type: http}
             - {name: ezplatform.http_cache.purge_client, purge_type: varnish}

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -75,13 +75,13 @@ class VarnishPurgeClientTest extends TestCase
     public function testPurgeOneLocationIdWithAuthHeaderAndKey()
     {
         $locationId = 123;
-        $authHeader = 'AUTH-HEADER-NAME';
-        $authKey = 'secret-auth-key';
+        $tokenName = 'x-purge-token-name';
+        $token = 'secret-token-key';
 
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $authHeader => $authKey]);
+            ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(2))
@@ -93,7 +93,7 @@ class VarnishPurgeClientTest extends TestCase
             ->expects($this->exactly(2))
             ->method('getParameter')
             ->withAnyParameters()
-            ->willReturn($authHeader, $authKey);
+            ->willReturn($tokenName, $token);
 
         $this->purgeClient->purge($locationId);
     }
@@ -118,38 +118,38 @@ class VarnishPurgeClientTest extends TestCase
      */
     public function testPurgeWithAuthHeaderAndKey(array $locationIds = [])
     {
-        $authHeader = 'AUTH-HEADER-NAME';
-        $authKey = 'secret-auth-key';
+        $tokenName = 'x-purge-token-name';
+        $token = 'secret-token-key';
 
         foreach ($locationIds as $key => $locationId) {
             $this->configResolver
                 ->expects($this->at($key * 4))
                 ->method('hasParameter')
-                ->with(VarnishPurgeClient::PURGE_AUTH_HEADER_PARAM)
-                ->willReturn($authHeader);
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_NAME_PARAM)
+                ->willReturn($tokenName);
 
             $this->configResolver
                 ->expects($this->at($key * 4 + 1))
                 ->method('hasParameter')
-                ->with(VarnishPurgeClient::PURGE_AUTH_KEY_PARAM)
-                ->willReturn($authKey);
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
+                ->willReturn($token);
 
             $this->configResolver
                 ->expects($this->at($key * 4 + 2))
                 ->method('getParameter')
-                ->with(VarnishPurgeClient::PURGE_AUTH_HEADER_PARAM)
-                ->willReturn($authHeader);
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_NAME_PARAM)
+                ->willReturn($tokenName);
 
             $this->configResolver
                 ->expects($this->at($key * 4 + 3))
                 ->method('getParameter')
-                ->with(VarnishPurgeClient::PURGE_AUTH_KEY_PARAM)
-                ->willReturn($authKey);
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
+                ->willReturn($token);
 
             $this->cacheManager
                 ->expects($this->at($key))
                 ->method('invalidatePath')
-                ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $authHeader => $authKey]);
+                ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $tokenName => $token]);
         }
 
         $this->purgeClient->purge($locationIds);
@@ -176,13 +176,13 @@ class VarnishPurgeClientTest extends TestCase
 
     public function testPurgeAllWithAuthHeaderAndKey()
     {
-        $authHeader = 'AUTH-HEADER-NAME';
-        $authKey = 'secret-auth-key';
+        $tokenName = 'x-purge-token-name';
+        $token = 'secret-token-key';
 
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => 'ez-all', 'Host' => 'localhost', $authHeader => $authKey]);
+            ->with('/', ['key' => 'ez-all', 'Host' => 'localhost', $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(2))
@@ -194,7 +194,7 @@ class VarnishPurgeClientTest extends TestCase
             ->expects($this->exactly(2))
             ->method('getParameter')
             ->withAnyParameters()
-            ->willReturn($authHeader, $authKey);
+            ->willReturn($tokenName, $token);
 
         $this->purgeClient->purgeAll();
     }

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -75,7 +75,7 @@ class VarnishPurgeClientTest extends TestCase
     public function testPurgeOneLocationIdWithAuthHeaderAndKey()
     {
         $locationId = 123;
-        $tokenName = 'x-purge-token-name';
+        $tokenName = 'x-purge-token';
         $token = 'secret-token-key';
 
         $this->cacheManager
@@ -84,16 +84,16 @@ class VarnishPurgeClientTest extends TestCase
             ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $tokenName => $token]);
 
         $this->configResolver
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method('hasParameter')
             ->withAnyParameters()
             ->willReturn(true);
 
         $this->configResolver
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method('getParameter')
             ->withAnyParameters()
-            ->willReturn($tokenName, $token);
+            ->willReturn($token);
 
         $this->purgeClient->purge($locationId);
     }
@@ -118,30 +118,18 @@ class VarnishPurgeClientTest extends TestCase
      */
     public function testPurgeWithAuthHeaderAndKey(array $locationIds = [])
     {
-        $tokenName = 'x-purge-token-name';
+        $tokenName = 'x-purge-token';
         $token = 'secret-token-key';
 
         foreach ($locationIds as $key => $locationId) {
             $this->configResolver
-                ->expects($this->at($key * 4))
-                ->method('hasParameter')
-                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_NAME_PARAM)
-                ->willReturn($tokenName);
-
-            $this->configResolver
-                ->expects($this->at($key * 4 + 1))
+                ->expects($this->at($key * 2))
                 ->method('hasParameter')
                 ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
                 ->willReturn($token);
 
             $this->configResolver
-                ->expects($this->at($key * 4 + 2))
-                ->method('getParameter')
-                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_NAME_PARAM)
-                ->willReturn($tokenName);
-
-            $this->configResolver
-                ->expects($this->at($key * 4 + 3))
+                ->expects($this->at($key * 2 + 1))
                 ->method('getParameter')
                 ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
                 ->willReturn($token);
@@ -176,7 +164,7 @@ class VarnishPurgeClientTest extends TestCase
 
     public function testPurgeAllWithAuthHeaderAndKey()
     {
-        $tokenName = 'x-purge-token-name';
+        $tokenName = 'x-purge-token';
         $token = 'secret-token-key';
 
         $this->cacheManager
@@ -185,16 +173,16 @@ class VarnishPurgeClientTest extends TestCase
             ->with('/', ['key' => 'ez-all', 'Host' => 'localhost', $tokenName => $token]);
 
         $this->configResolver
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method('hasParameter')
             ->withAnyParameters()
             ->willReturn(true);
 
         $this->configResolver
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method('getParameter')
             ->withAnyParameters()
-            ->willReturn($tokenName, $token);
+            ->willReturn($token);
 
         $this->purgeClient->purgeAll();
     }


### PR DESCRIPTION
Meta repo changes:

default_parameters.yml
```
    varnish_invalidate_token: '%env(HTTPCACHE_VARNISH_INVALIDATE_TOKEN)%'

    env(HTTPCACHE_VARNISH_INVALIDATE_TOKEN): ~
```

ezplatform.yml
```
ezpublish:
...
	system:
	...
		site_group: (same for admin_group)
            		http_cache:
			        purge_servers: ['%purge_server%']
+             			varnish_invalidate_token: '%varnish_invalidate_token%'
```

.env
```
# Enable varnish purging invalidate token by setting valid token
#HTTPCACHE_VARNISH_INVALIDATE_TOKEN=""
```

https://jira.ez.no/browse/EZP-29817