### PR TITLE
EZP-29194: Improve repo prefix handling for purgeAll() and user context hash tagging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "0.8.x-dev",
-            "dev-tmp_ci_branch": "0.7.x-dev"
+            "dev-tmp_ci_branch": "0.8.x-dev"
         }
     }
 }

--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -95,7 +95,7 @@ class TagHandlerSpec extends ObjectBehavior
 
     public function it_tags_all_tags_we_add_and_prefix_with_repo_id(Response $response, ResponseHeaderBag $responseHeaderBag)
     {
-        $responseHeaderBag->set('xkey', Argument::exact('intranet_ez-all intranet_location-4 intranet_content-4 intranet_path-2'))->shouldBeCalled();
+        $responseHeaderBag->set('xkey', Argument::exact('intranet_ez-all intranet_location-4 intranet_content-4 intranet_path-2 ez-all'))->shouldBeCalled();
 
         $this->addTags(['location-4', 'content-4']);
         $this->addTags(['path-2']);
@@ -107,7 +107,7 @@ class TagHandlerSpec extends ObjectBehavior
     {
         $responseHeaderBag->has('xkey')->willReturn(true);
         $responseHeaderBag->get('xkey', null, false)->willReturn(['tag1']);
-        $responseHeaderBag->set('xkey', Argument::exact('intranet_tag1 intranet_ez-all intranet_location-4 intranet_content-4 intranet_path-2'))->shouldBeCalled();
+        $responseHeaderBag->set('xkey', Argument::exact('intranet_tag1 intranet_ez-all intranet_location-4 intranet_content-4 intranet_path-2 ez-all'))->shouldBeCalled();
 
         $this->addTags(['location-4', 'content-4']);
         $this->addTags(['path-2']);

--- a/src/EventSubscriber/UserContextSubscriber.php
+++ b/src/EventSubscriber/UserContextSubscriber.php
@@ -17,9 +17,13 @@ class UserContextSubscriber implements EventSubscriberInterface
     /** @var string */
     private $tagHeader = 'xkey';
 
-    public function __construct($tagHeader)
+    /** @var string */
+    private $repoPrefix;
+
+    public function __construct($tagHeader, $repositoryId)
     {
         $this->tagHeader = $tagHeader;
+        $this->repoPrefix = empty($repositoryId) ? '' : $repositoryId . '_';
     }
 
     public static function getSubscribedEvents()
@@ -49,6 +53,6 @@ class UserContextSubscriber implements EventSubscriberInterface
 
         // We need to set tag directly on repsonse here to make sure this does not also get applied to the main request
         // when using Symfony Proxy, as tag handler does not clear tags between requests.
-        $response->headers->set($this->tagHeader, 'ez-user-context-hash');
+        $response->headers->set($this->tagHeader, $this->repoPrefix . 'ez-user-context-hash');
     }
 }

--- a/src/EventSubscriber/UserContextSubscriber.php
+++ b/src/EventSubscriber/UserContextSubscriber.php
@@ -18,11 +18,15 @@ class UserContextSubscriber implements EventSubscriberInterface
     private $tagHeader = 'xkey';
 
     /** @var string */
-    private $repoPrefix;
+    private $repoPrefix = '';
 
-    public function __construct($tagHeader, $repositoryId)
+    public function __construct($tagHeader)
     {
         $this->tagHeader = $tagHeader;
+    }
+
+    public function setRepositoryId($repositoryId)
+    {
         $this->repoPrefix = empty($repositoryId) ? '' : $repositoryId . '_';
     }
 

--- a/src/PurgeClient/PurgeClientInterface.php
+++ b/src/PurgeClient/PurgeClientInterface.php
@@ -25,5 +25,5 @@ interface PurgeClientInterface
      *
      * @param string|null $allTagName The tag name used for all eZ cache, "ez-all" prefixed for repository name.
      */
-    public function purgeAll(/*string $allTagName = 'ez-all'*/);
+    public function purgeAll(/*$allTagName = 'ez-all'*/);
 }

--- a/src/PurgeClient/PurgeClientInterface.php
+++ b/src/PurgeClient/PurgeClientInterface.php
@@ -23,7 +23,7 @@ interface PurgeClientInterface
     /**
      * Purge the whole http cache.
      *
-     * @param string|null $allTagName The tag name used for all eZ cache, "ez-all" prefixed for repository name.
+     * This will purge cache for all repositories, to purge for only current repository call ::purge(['ez-all']).
      */
-    public function purgeAll(/*$allTagName = 'ez-all'*/);
+    public function purgeAll();
 }

--- a/src/PurgeClient/PurgeClientInterface.php
+++ b/src/PurgeClient/PurgeClientInterface.php
@@ -16,12 +16,14 @@ interface PurgeClientInterface
      *
      * It's up to the implementor to decide whether to purge tags right away or to delegate to a separate process.
      *
-     * @param array $tags Array of tags to purge
+     * @param array|int $tags Array of tags to purge, int for BC (location-<int>).
      */
     public function purge($tags);
 
     /**
      * Purge the whole http cache.
+     *
+     * @param string|null $allTagName The tag name used for all eZ cache, "ez-all" prefixed for repository name.
      */
-    public function purgeAll();
+    public function purgeAll(/*string $allTagName = 'ez-all'*/);
 }

--- a/src/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/PurgeClient/RepositoryPrefixDecorator.php
@@ -47,8 +47,8 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
         $this->purgeClient->purge($tags);
     }
 
-    public function purgeAll()
+    public function purgeAll($allTagName = 'ez-all')
     {
-        $this->purgeClient->purgeAll($this->repoPrefix . 'ez-all');
+        $this->purgeClient->purgeAll($this->repoPrefix . $allTagName);
     }
 }

--- a/src/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/PurgeClient/RepositoryPrefixDecorator.php
@@ -19,11 +19,15 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
     private $purgeClient;
 
     /** @var string */
-    private $repoPrefix;
+    private $repoPrefix = '';
 
-    public function __construct(PurgeClientInterface $purgeClient, $repositoryId)
+    public function __construct(PurgeClientInterface $purgeClient)
     {
         $this->purgeClient = $purgeClient;
+    }
+
+    public function setRepositoryId($repositoryId)
+    {
         $this->repoPrefix = empty($repositoryId) ? '' : $repositoryId . '_';
     }
 
@@ -47,8 +51,8 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
         $this->purgeClient->purge($tags);
     }
 
-    public function purgeAll($allTagName = 'ez-all')
+    public function purgeAll()
     {
-        $this->purgeClient->purgeAll($this->repoPrefix . $allTagName);
+        $this->purgeClient->purgeAll();
     }
 }

--- a/src/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/PurgeClient/RepositoryPrefixDecorator.php
@@ -49,6 +49,6 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
 
     public function purgeAll()
     {
-        $this->purgeClient->purgeAll();
+        $this->purgeClient->purgeAll($this->repoPrefix . 'ez-all');
     }
 }

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -48,11 +48,11 @@ class VarnishPurgeClient implements PurgeClientInterface
         }
     }
 
-    public function purgeAll($allTagName = 'ez-all')
+    public function purgeAll()
     {
         $this->cacheManager->invalidatePath(
             '/',
-            ['key' => $allTagName, 'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME']]
+            ['key' => 'ez-all', 'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME']]
         );
     }
 }

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -48,11 +48,11 @@ class VarnishPurgeClient implements PurgeClientInterface
         }
     }
 
-    public function purgeAll()
+    public function purgeAll(string $allTagName = 'ez-all')
     {
         $this->cacheManager->invalidatePath(
             '/',
-            ['key' => 'ez-all', 'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME']]
+            ['key' => $allTagName, 'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME']]
         );
     }
 }

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -48,7 +48,7 @@ class VarnishPurgeClient implements PurgeClientInterface
         }
     }
 
-    public function purgeAll(string $allTagName = 'ez-all')
+    public function purgeAll($allTagName = 'ez-all')
     {
         $this->cacheManager->invalidatePath(
             '/',

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -12,7 +12,10 @@ services:
 
     ezplatform.http_cache.purge_client_decorator:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\RepositoryPrefixDecorator
-        arguments: ['@ezplatform.http_cache.purge_client_internal', $repository$]
+        arguments: ['@ezplatform.http_cache.purge_client_internal']
+        # Use setter to avoid SiteAccess system creating two instances of handler before and after SiteAccess is set
+        calls:
+            - [setRepositoryId, [$repository$]]
 
     ezplatform.http_cache.purge_client_internal:
         alias: ezplatform.http_cache.purge_client.local
@@ -43,7 +46,7 @@ services:
          - '@ezplatform.http_cache.cache_manager'
          - '%ezplatform.http_cache.tags.header%'
          - '@ezplatform.http_cache.purge_client'
-        # To avoid SiteAccess system creating two instances of handler before and after siteaccess is set, use setter for SA settings
+        # Use setter to avoid SiteAccess system creating two instances of handler before and after SiteAccess is set
         calls:
             - [setRepositoryId, [$repository$]]
 

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -22,7 +22,10 @@ services:
 
     ezplatform.user_context_tagger.response_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSubscriber
-        arguments: ['%ezplatform.http_cache.tags.header%', $repository$]
+        arguments: ['%ezplatform.http_cache.tags.header%']
+        # Use setter to avoid SiteAccess system creating two instances of handler before and after SiteAccess is set
+        calls:
+            - [setRepositoryId, [$repository$]]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -22,7 +22,7 @@ services:
 
     ezplatform.user_context_tagger.response_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSubscriber
-        arguments: ['%ezplatform.http_cache.tags.header%']
+        arguments: ['%ezplatform.http_cache.tags.header%', $repository$]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * File containing the RepositoryPrefixDecoratorTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient;
+
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\RepositoryPrefixDecorator;
+use PHPUnit\Framework\TestCase;
+
+class RepositoryPrefixDecoratorTest extends TestCase
+{
+    public function testPurge()
+    {
+        $purgeClient = $this->createMock(PurgeClientInterface::class);
+        $purgeClient
+            ->expects($this->once())
+            ->method('purge')
+            ->with($this->equalTo(['location-123', 'content-44', 'ez-all']));
+
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, '');
+        $prefixDecorator->purge([123, 'content-44', 'ez-all']);
+    }
+
+    public function testPurgeWithPrefix()
+    {
+        $purgeClient = $this->createMock(PurgeClientInterface::class);
+        $purgeClient
+            ->expects($this->once())
+            ->method('purge')
+            ->with($this->equalTo(['intranet_location-123', 'intranet_content-44', 'intranet_ez-all']));
+
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, 'intranet');
+        $prefixDecorator->purge([123, 'content-44', 'ez-all']);
+    }
+
+    public function testPurgeAll()
+    {
+        $purgeClient = $this->createMock(PurgeClientInterface::class);
+        $purgeClient
+            ->expects($this->once())
+            ->method('purgeAll')
+            ->with($this->equalTo('ez-all'));
+
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, '');
+        $prefixDecorator->purgeAll();
+    }
+
+    public function testPurgeAllWithPrefix()
+    {
+        $purgeClient = $this->createMock(PurgeClientInterface::class);
+        $purgeClient
+            ->expects($this->once())
+            ->method('purgeAll')
+            ->with($this->equalTo('intranet_ez-all'));
+
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, 'intranet');
+        $prefixDecorator->purgeAll();
+    }
+}

--- a/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -22,7 +22,7 @@ class RepositoryPrefixDecoratorTest extends TestCase
             ->method('purge')
             ->with($this->equalTo(['location-123', 'content-44', 'ez-all']));
 
-        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, '');
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient);
         $prefixDecorator->purge([123, 'content-44', 'ez-all']);
     }
 
@@ -34,7 +34,8 @@ class RepositoryPrefixDecoratorTest extends TestCase
             ->method('purge')
             ->with($this->equalTo(['intranet_location-123', 'intranet_content-44', 'intranet_ez-all']));
 
-        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, 'intranet');
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient);
+        $prefixDecorator->setRepositoryId('intranet');
         $prefixDecorator->purge([123, 'content-44', 'ez-all']);
     }
 
@@ -43,10 +44,9 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $purgeClient = $this->createMock(PurgeClientInterface::class);
         $purgeClient
             ->expects($this->once())
-            ->method('purgeAll')
-            ->with($this->equalTo('ez-all'));
+            ->method('purgeAll');
 
-        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, '');
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient);
         $prefixDecorator->purgeAll();
     }
 
@@ -55,10 +55,10 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $purgeClient = $this->createMock(PurgeClientInterface::class);
         $purgeClient
             ->expects($this->once())
-            ->method('purgeAll')
-            ->with($this->equalTo('intranet_ez-all'));
+            ->method('purgeAll');
 
-        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient, 'intranet');
+        $prefixDecorator = new RepositoryPrefixDecorator($purgeClient);
+        $prefixDecorator->setRepositoryId('intranet');
         $prefixDecorator->purgeAll();
     }
 }


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-29194

Followup to fix the following edge cases:
* Prefix tag for user context hash, so it can be correctly purged when repo prefixes er in use
* Always tag responses with unprefixed `ez-all`, as this is used in `purgeAll()` on Varnish and Fastly. Makes sure `purgeAll()` works the same in all Proxies; clearing _all_ cache across all repositories.
  * Note: To clear all cache but only for a specific repo, use _(`purge(['ez-all'])`)_ or from command line using fos command to clear by `ez-all` tag, these calls will/should be prefixed.

Follow up on this is to add a optional cache clearer for symfony that takes advantage of the fixes in purgeAll() to call that when user is calling `bin/console cache:clear`