### PR TITLE
Allow https scheme for ProxyClient

### DIFF
--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * File containing the Varnish class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\ProxyClient;
+
+use FOS\HttpCache\ProxyClient\Varnish as FOSVarnish;
+
+/**
+ * Class Varnish.
+ *
+ * We need to support https as Platform.sh uses https by default.
+ */
+class Varnish extends FOSVarnish
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAllowedSchemes()
+    {
+        return array('http', 'https');
+    }
+}

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -53,7 +53,7 @@ class VarnishPurgeClient implements PurgeClientInterface
 
             $headers = [
                 'key' => $tag,
-                'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME'],
+                'Host' => empty($_SERVER['SERVER_NAME']) ? parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST) : $_SERVER['SERVER_NAME'],
             ];
 
             $headers = $this->addPurgeAuthHeader($headers);
@@ -69,7 +69,7 @@ class VarnishPurgeClient implements PurgeClientInterface
     {
         $headers = [
             'key' => 'ez-all',
-            'Host' => empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME'],
+            'Host' => empty($_SERVER['SERVER_NAME']) ? parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST) : $_SERVER['SERVER_NAME'],
         ];
 
         $headers = $this->addPurgeAuthHeader($headers);

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,3 +1,6 @@
+parameters:
+    ezplatform.http_cache.proxy_client.varnish.class: EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish
+
 services:
     ezplatform.http_cache.cache_manager:
         parent: fos_http_cache.cache_manager
@@ -5,7 +8,7 @@ services:
 
     ezplatform.http_cache.proxy_client.varnish.factory:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishProxyClientFactory
-        arguments: ['@ezpublish.config.resolver', '@ezpublish.config.dynamic_setting.parser', '%fos_http_cache.proxy_client.varnish.class%']
+        arguments: ['@ezpublish.config.resolver', '@ezpublish.config.dynamic_setting.parser', '%ezplatform.http_cache.proxy_client.varnish.class%']
 
     ezplatform.http_cache.purge_client:
         alias: ezplatform.http_cache.purge_client_decorator

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -67,7 +67,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost']);
+            ->with('/', ['key' => "location-$locationId", 'Host' => null]);
 
         $this->purgeClient->purge($locationId);
     }
@@ -81,7 +81,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $tokenName => $token]);
+            ->with('/', ['key' => "location-$locationId", 'Host' => null, $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(1))
@@ -107,7 +107,7 @@ class VarnishPurgeClientTest extends TestCase
             $this->cacheManager
                 ->expects($this->at($key))
                 ->method('invalidatePath')
-                ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost']);
+                ->with('/', ['key' => "location-$locationId", 'Host' => null]);
         }
 
         $this->purgeClient->purge($locationIds);
@@ -137,7 +137,7 @@ class VarnishPurgeClientTest extends TestCase
             $this->cacheManager
                 ->expects($this->at($key))
                 ->method('invalidatePath')
-                ->with('/', ['key' => "location-$locationId", 'Host' => 'localhost', $tokenName => $token]);
+                ->with('/', ['key' => "location-$locationId", 'Host' => null, $tokenName => $token]);
         }
 
         $this->purgeClient->purge($locationIds);
@@ -157,7 +157,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => 'ez-all', 'Host' => 'localhost']);
+            ->with('/', ['key' => 'ez-all', 'Host' => null]);
 
         $this->purgeClient->purgeAll();
     }
@@ -170,7 +170,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => 'ez-all', 'Host' => 'localhost', $tokenName => $token]);
+            ->with('/', ['key' => 'ez-all', 'Host' => null, $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(1))

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -64,10 +64,23 @@ class VarnishPurgeClientTest extends TestCase
     public function testPurgeOneLocationId()
     {
         $locationId = 123;
+
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => null]);
+            ->with('/', ['key' => "location-$locationId", 'Host' => 'varnishpurgehost']);
+
+        $this->configResolver
+            ->expects($this->exactly(1))
+            ->method('hasParameter')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $this->configResolver
+            ->expects($this->exactly(2))
+            ->method('getParameter')
+            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM])
+            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], null);
 
         $this->purgeClient->purge($locationId);
     }
@@ -81,7 +94,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => null, $tokenName => $token]);
+            ->with('/', ['key' => "location-$locationId", 'Host' => 'varnishpurgehost', $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(1))
@@ -90,10 +103,10 @@ class VarnishPurgeClientTest extends TestCase
             ->willReturn(true);
 
         $this->configResolver
-            ->expects($this->exactly(1))
+            ->expects($this->exactly(2))
             ->method('getParameter')
-            ->withAnyParameters()
-            ->willReturn($token);
+            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM])
+            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], $token);
 
         $this->purgeClient->purge($locationId);
     }
@@ -104,10 +117,28 @@ class VarnishPurgeClientTest extends TestCase
     public function testPurge(array $locationIds)
     {
         foreach ($locationIds as $key => $locationId) {
+            $this->configResolver
+                ->expects($this->at($key * 3))
+                ->method('getParameter')
+                ->with('http_cache.purge_servers')
+                ->willReturn(['https://varnishpurgehost']);
+
+            $this->configResolver
+                ->expects($this->at($key * 3 + 1))
+                ->method('hasParameter')
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
+                ->willReturn(true);
+
+            $this->configResolver
+                ->expects($this->at($key * 3 + 2))
+                ->method('getParameter')
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
+                ->willReturn(null);
+
             $this->cacheManager
                 ->expects($this->at($key))
                 ->method('invalidatePath')
-                ->with('/', ['key' => "location-$locationId", 'Host' => null]);
+                ->with('/', ['key' => "location-$locationId", 'Host' => 'varnishpurgehost']);
         }
 
         $this->purgeClient->purge($locationIds);
@@ -123,13 +154,19 @@ class VarnishPurgeClientTest extends TestCase
 
         foreach ($locationIds as $key => $locationId) {
             $this->configResolver
-                ->expects($this->at($key * 2))
-                ->method('hasParameter')
-                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
-                ->willReturn($token);
+                ->expects($this->at($key * 3))
+                ->method('getParameter')
+                ->with('http_cache.purge_servers')
+                ->willReturn(['https://varnishpurgehost']);
 
             $this->configResolver
-                ->expects($this->at($key * 2 + 1))
+                ->expects($this->at($key * 3 + 1))
+                ->method('hasParameter')
+                ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
+                ->willReturn(true);
+
+            $this->configResolver
+                ->expects($this->at($key * 3 + 2))
                 ->method('getParameter')
                 ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
                 ->willReturn($token);
@@ -137,7 +174,7 @@ class VarnishPurgeClientTest extends TestCase
             $this->cacheManager
                 ->expects($this->at($key))
                 ->method('invalidatePath')
-                ->with('/', ['key' => "location-$locationId", 'Host' => null, $tokenName => $token]);
+                ->with('/', ['key' => "location-$locationId", 'Host' => 'varnishpurgehost', $tokenName => $token]);
         }
 
         $this->purgeClient->purge($locationIds);
@@ -157,7 +194,19 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => 'ez-all', 'Host' => null]);
+            ->with('/', ['key' => 'ez-all', 'Host' => 'varnishpurgehost']);
+
+        $this->configResolver
+            ->expects($this->exactly(1))
+            ->method('hasParameter')
+            ->withAnyParameters()
+            ->willReturn(true);
+
+        $this->configResolver
+            ->expects($this->exactly(2))
+            ->method('getParameter')
+            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM])
+            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], null);
 
         $this->purgeClient->purgeAll();
     }
@@ -170,7 +219,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => 'ez-all', 'Host' => null, $tokenName => $token]);
+            ->with('/', ['key' => 'ez-all', 'Host' => 'varnishpurgehost', $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(1))
@@ -179,10 +228,10 @@ class VarnishPurgeClientTest extends TestCase
             ->willReturn(true);
 
         $this->configResolver
-            ->expects($this->exactly(1))
+            ->expects($this->exactly(2))
             ->method('getParameter')
-            ->withAnyParameters()
-            ->willReturn($token);
+            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM])
+            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], $token);
 
         $this->purgeClient->purgeAll();
     }


### PR DESCRIPTION
Our [default routes](https://github.com/ezsystems/ezplatform/blob/master/.platform/routes.yaml) on Platform.sh only have https. So in order to send purge requests on Platform.sh, we need to support sending purge requests via HTTPS