### PR TITLE
[TBD] Implement cache clearer to purge http cache on "cache:clear"

### DIFF
--- a/src/CacheClearer/HttpCacheClearer.php
+++ b/src/CacheClearer/HttpCacheClearer.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\CacheClearer;
+
+use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+/**
+ * Cache cleared for purging all http cache on cache:clear.
+ */
+class HttpCacheClearer implements CacheClearerInterface
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface
+     */
+    protected $purgeClient;
+
+    public function __construct(PurgeClientInterface $purgeClient)
+    {
+        $this->purgeClient = $purgeClient;
+    }
+
+    public function clear($cacheDirectory)
+    {
+        // In the case of Varnish & Fastly this results in a expiry and not a purge
+        // Meaning the cache items might still be served up to the time of the grace/stale period
+
+        // @todo: Ideally should be a way to opt out of this when needed, but cache warmers is not a good match either
+        $this->purgeClient->purgeAll();
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -57,3 +57,9 @@ services:
         arguments: ["@ezpublish.api.repository"]
         tags:
             - { name: fos_http_cache.user_context_provider }
+
+    ezplatform.http_cache.http_cache_clearer:
+        class: EzSystems\PlatformHttpCacheBundle\CacheClearer\HttpCacheClearer
+        arguments: ["@ezplatform.http_cache.purge_client"]
+        tags:
+            - { name: kernel.cache_clearer }


### PR DESCRIPTION
Adds support for purging all http cache when developer runs `cache:clear` command
_Takes advantage of the recent fixes on purgeAll()_

TBD: _Several people have asked for it, but I'm far from sure everyone wants it with no way to opt out._