### PR TITLE
[Cloud feature] Purge token controller

### DIFF
--- a/docs/varnish/vcl/varnish4.vcl
+++ b/docs/varnish/vcl/varnish4.vcl
@@ -127,6 +127,8 @@ sub vcl_backend_response {
 // You may add FOSHttpCacheBundle tagging rules
 // See http://foshttpcache.readthedocs.org/en/latest/varnish-configuration.html#id4
 sub ez_purge {
+    // Retrieve purge token, needs to be here due to restart, match for PURGE method done within
+    call ez_invalidate_token;
 
     # Support how purging was done in earlier versions, this is deprecated and here just for BC for code still using it
     if (req.method == "BAN") {
@@ -159,13 +161,11 @@ sub ez_purge {
 }
 
 sub ez_purge_acl {
-//    if (req.http.x-purge-token) {
-//        #  Won't work on Varnish <= 5.1, if needed in 4.1 you can hardcode a secret token here instead of std.getenv() usage
-//        if (req.http.x-purge-token != std.getenv("HTTPCACHE_VARNISH_INVALIDATE_TOKEN")) {
-//            return (synth(405, "Method not allowed"));
-//        }
-//    } else if  (!client.ip ~ invalidators) {
-    if  (!client.ip ~ invalidators) {
+    if (req.http.x-invalidate-token) {
+        if (req.http.x-invalidate-token != req.http.x-backend-invalidate-token) {
+            return (synth(405, "Method not allowed"));
+        }
+    } else if  (!client.ip ~ invalidators) {
         return (synth(405, "Method not allowed"));
     }
 }
@@ -219,7 +219,47 @@ sub ez_user_context_hash {
     }
 }
 
+// Sub-routine to get invalidate token.
+sub ez_invalidate_token {
+    // Prevent tampering attacks on the token mechanisms
+    if (req.restarts == 0
+        && (req.http.accept ~ "application/vnd.ezplatform.invalidate-token"
+            || req.http.x-backend-invalidate-token
+        )
+    ) {
+        return (synth(400));
+    }
+
+    if (req.restarts == 0 && req.method == "PURGE" && req.http.x-invalidate-token) {
+        set req.http.accept = "application/vnd.ezplatform.invalidate-token";
+
+        set req.url = "/_ez_http_invalidatetoken";
+
+        // Force the lookup
+        return (hash);
+    }
+
+    // Rebuild the original request which now has the invalidate token.
+    if (req.restarts > 0
+        && req.http.accept == "application/vnd.ezplatform.invalidate-token"
+    ) {
+        set req.url = "/";
+        set req.method = "PURGE";
+        unset req.http.accept;
+    }
+}
+
 sub vcl_deliver {
+    // On receiving the invalidate token response, copy the invalidate token to the original
+    // request and restart.
+    if (req.restarts == 0
+        && resp.http.content-type ~ "application/vnd.ezplatform.invalidate-token"
+    ) {
+        set req.http.x-backend-invalidate-token = resp.http.x-invalidate-token;
+
+        return (restart);
+    }
+
     // On receiving the hash response, copy the hash header to the original
     // request and restart.
     if (req.restarts == 0

--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -124,6 +124,8 @@ sub vcl_backend_response {
 // You may add FOSHttpCacheBundle tagging rules
 // See http://foshttpcache.readthedocs.org/en/latest/varnish-configuration.html#id4
 sub ez_purge {
+    // Retrieve purge token, needs to be here due to restart, match for PURGE method done within
+    call ez_invalidate_token;
 
     # Support how purging was done in earlier versions, this is deprecated and here just for BC for code still using it
     if (req.method == "BAN") {
@@ -156,13 +158,11 @@ sub ez_purge {
 }
 
 sub ez_purge_acl {
-//    if (req.http.x-purge-token) {
-//        #  Won't work on Varnish <= 5.1, if needed in 4.1 you can hardcode a secret token here instead of std.getenv() usage
-//        if (req.http.x-purge-token != std.getenv("HTTPCACHE_VARNISH_INVALIDATE_TOKEN")) {
-//            return (synth(405, "Method not allowed"));
-//        }
-//    } else if  (!client.ip ~ invalidators) {
-    if  (!client.ip ~ invalidators) {
+    if (req.http.x-invalidate-token) {
+        if (req.http.x-invalidate-token != req.http.x-backend-invalidate-token) {
+            return (synth(405, "Method not allowed"));
+        }
+    } else if  (!client.ip ~ invalidators) {
         return (synth(405, "Method not allowed"));
     }
 }
@@ -216,7 +216,47 @@ sub ez_user_context_hash {
     }
 }
 
+// Sub-routine to get invalidate token.
+sub ez_invalidate_token {
+    // Prevent tampering attacks on the token mechanisms
+    if (req.restarts == 0
+        && (req.http.accept ~ "application/vnd.ezplatform.invalidate-token"
+            || req.http.x-backend-invalidate-token
+        )
+    ) {
+        return (synth(400));
+    }
+
+    if (req.restarts == 0 && req.method == "PURGE" && req.http.x-invalidate-token) {
+        set req.http.accept = "application/vnd.ezplatform.invalidate-token";
+
+        set req.url = "/_ez_http_invalidatetoken";
+
+        // Force the lookup
+        return (hash);
+    }
+
+    // Rebuild the original request which now has the invalidate token.
+    if (req.restarts > 0
+        && req.http.accept == "application/vnd.ezplatform.invalidate-token"
+    ) {
+        set req.url = "/";
+        set req.method = "PURGE";
+        unset req.http.accept;
+    }
+}
+
 sub vcl_deliver {
+    // On receiving the invalidate token response, copy the invalidate token to the original
+    // request and restart.
+    if (req.restarts == 0
+        && resp.http.content-type ~ "application/vnd.ezplatform.invalidate-token"
+    ) {
+        set req.http.x-backend-invalidate-token = resp.http.x-invalidate-token;
+
+        return (restart);
+    }
+
     // On receiving the hash response, copy the hash header to the original
     // request and restart.
     if (req.restarts == 0

--- a/src/Controller/InvalidateTokenController.php
+++ b/src/Controller/InvalidateTokenController.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\IpUtils;
+use FOS\HttpCacheBundle\Handler\TagHandler;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+class InvalidateTokenController
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var int
+     */
+    private $ttl;
+
+    /**
+     * @var FOS\HttpCacheBundle\Handler\TagHandler
+     */
+    private $tagHandler;
+
+    /**
+     * TokenController constructor.
+     * @param ConfigResolverInterface $configResolver
+     * @param int $ttl
+     * @param TagHandler $tagHandler
+     * @internal param string $invalidatetoken
+     */
+    public function __construct(ConfigResolverInterface $configResolver, $ttl, TagHandler $tagHandler)
+    {
+        $this->configResolver = $configResolver;
+        $this->ttl = $ttl;
+        $this->tagHandler = $tagHandler;
+    }
+
+    /**
+     * Request::isFromTrustedProxy is private in Symfony <3.1, so this is a re-implementation of it.
+     *
+     * @param Request $request
+     * @return bool
+     */
+    private function isFromTrustedProxy(Request $request)
+    {
+        return $request->getTrustedProxies() && IpUtils::checkIp($request->server->get('REMOTE_ADDR'), $request->getTrustedProxies());
+    }
+
+    /**
+     * @param Request $request
+     * @return Response
+     */
+    public function tokenAction(Request $request)
+    {
+        $response = new Response();
+
+        if (!$this->isFromTrustedProxy($request)) {
+            $response->setStatusCode('401', 'Unauthorized');
+
+            return $response;
+        }
+
+        // Important to keep this condition, as .vcl rely on this to prevent everyone from being able to fetch the token.
+        if ($request->headers->get('accept') !== 'application/vnd.ezplatform.invalidate-token') {
+            $response->setStatusCode('400', 'Bad request');
+
+            return $response;
+        }
+        $this->tagHandler->addTags(['ez-invalidate-token']);
+
+        $headers = $response->headers;
+        $headers->set('Content-Type', 'application/vnd.ezplatform.invalidate-token');
+        $headers->set('X-Invalidate-Token', $this->configResolver->getParameter('http_cache.varnish_invalidate_token'));
+        $response->setSharedMaxAge($this->ttl);
+        $response->setVary('Accept', true);
+
+        return $response;
+    }
+}

--- a/src/EventListener/ConditionallyRemoveVaryHeaderListener.php
+++ b/src/EventListener/ConditionallyRemoveVaryHeaderListener.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Class ConditionallyRemoveVaryHeaderListener
+ * Unfortunately, FOS\HttpCacheBundle\EventListener\UserContextSubscriber will set Vary header on all requests.
+ * This event listeners removes the $userIdentifierHeaders headers again in responses to any of the given $routes.
+ * For such routes, the controller should instead set the Vary header explicitly.
+ */
+class ConditionallyRemoveVaryHeaderListener implements EventSubscriberInterface
+{
+    /**
+     * @var string[]
+     */
+    private $routes;
+
+    /**
+     * @var string[]
+     */
+    private $userIdentifierHeaders;
+
+    /**
+     * ConditionallyRemoveVaryHeaderListener constructor.
+     * @param array $routes List of routes which will not have default vary headers
+     * @param array $userIdentifierHeaders
+     */
+    public function __construct(array $routes, array $userIdentifierHeaders = ['Cookie', 'Authorization'])
+    {
+        $this->routes = $routes;
+        $this->userIdentifierHeaders = $userIdentifierHeaders;
+    }
+
+    /**
+     * Remove Vary headers for matched routes.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST != $event->getRequestType()) {
+            return;
+        }
+
+        if (!in_array($event->getRequest()->get('_route'), $this->routes)) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $varyHeaders = $response->headers->get('vary', null, false);
+
+        foreach ($this->userIdentifierHeaders as $removableVary) {
+            unset($varyHeaders[array_search(strtolower($removableVary), $varyHeaders)]);
+        }
+        $response->setVary($varyHeaders, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
+    }
+}

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -15,7 +15,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 class VarnishPurgeClient implements PurgeClientInterface
 {
     const INVALIDATE_TOKEN_PARAM = 'http_cache.varnish_invalidate_token';
-    const INVALIDATE_TOKEN_PARAM_NAME = 'x-purge-token';
+    const INVALIDATE_TOKEN_PARAM_NAME = 'x-invalidate-token';
 
     /**
      * @var \FOS\HttpCacheBundle\CacheManager

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -1,3 +1,5 @@
 parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ezplatform.http_cache.tags.header: 'xkey'
+    ezplatform.http_cache.invalidate_token.ttl: 86400
+    ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,0 +1,5 @@
+
+ezplatform.httpcache.invalidatetoken:
+    path: /_ez_http_invalidatetoken
+    defaults:
+      _controller: ezplatform.http_cache.controller.invalidatetoken:tokenAction

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,5 +1,7 @@
 parameters:
     ezplatform.http_cache.proxy_client.varnish.class: EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish
+    ezplatform.http_cache.controller.invalidatetoken.class: EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController
+    ezplatform.http_cache.listener.vary_header.class: EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener
 
 services:
     ezplatform.http_cache.cache_manager:
@@ -60,3 +62,17 @@ services:
         arguments: ["@ezpublish.api.repository"]
         tags:
             - { name: fos_http_cache.user_context_provider }
+
+    ezplatform.http_cache.controller.invalidatetoken:
+        class: "%ezplatform.http_cache.controller.invalidatetoken.class%"
+        arguments:
+         - '@ezpublish.config.resolver'
+         - "%ezplatform.http_cache.invalidate_token.ttl%"
+         - "@fos_http_cache.handler.tag_handler"
+
+    ezplatform.http_cache.listener.vary_header:
+        class: "%ezplatform.http_cache.listener.vary_header.class%"
+        arguments:
+         - "%ezplatform.http_cache.no_vary.routes%"
+        tags:
+            - { name: kernel.event_subscriber, priority: -100 }

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -88,7 +88,7 @@ class VarnishPurgeClientTest extends TestCase
     public function testPurgeOneLocationIdWithAuthHeaderAndKey()
     {
         $locationId = 123;
-        $tokenName = 'x-purge-token';
+        $tokenName = VarnishPurgeClient::INVALIDATE_TOKEN_PARAM_NAME;
         $token = 'secret-token-key';
 
         $this->cacheManager
@@ -149,7 +149,7 @@ class VarnishPurgeClientTest extends TestCase
      */
     public function testPurgeWithAuthHeaderAndKey(array $locationIds = [])
     {
-        $tokenName = 'x-purge-token';
+        $tokenName = VarnishPurgeClient::INVALIDATE_TOKEN_PARAM_NAME;
         $token = 'secret-token-key';
 
         foreach ($locationIds as $key => $locationId) {
@@ -213,7 +213,7 @@ class VarnishPurgeClientTest extends TestCase
 
     public function testPurgeAllWithAuthHeaderAndKey()
     {
-        $tokenName = 'x-purge-token';
+        $tokenName = VarnishPurgeClient::INVALIDATE_TOKEN_PARAM_NAME;
         $token = 'secret-token-key';
 
         $this->cacheManager


### PR DESCRIPTION
This makes it possible for varnish to fetch the purge token from the backend. This is needed on Platform.sh as it is not possible to inject environment variables into varnish container.

With this change we don't need to use environment variables in .vcl so I have removed that part