### PR TITLE
Changed how FOS' proxyclient is overriden without breaking fastly bundle

### DIFF
--- a/src/DependencyInjection/Compiler/HttpCachePass.php
+++ b/src/DependencyInjection/Compiler/HttpCachePass.php
@@ -57,18 +57,7 @@ class HttpCachePass implements CompilerPassInterface
 
     public function setProxyClient(ContainerBuilder $container)
     {
-        // In 1.13, ezpublish-kernel will inject the fos proxy client into the VarnishProxyClientFactory
-        // We need to inject our own ProxyClient
-        if ($container->hasDefinition('ezpublish.http_cache.proxy_client.varnish.factory')) {
-            $def = $container->getDefinition('ezpublish.http_cache.proxy_client.varnish.factory');
-            $arguments = $def->getArguments();
-            if (count($arguments) == 3) {
-                $proxyClientClassArg = $arguments[2];
-                if ($proxyClientClassArg === '%fos_http_cache.proxy_client.varnish.class%') {
-                    $arguments[2] = '%ezplatform.http_cache.proxy_client.varnish.class%';
-                    $def->setArguments($arguments);
-                }
-            }
-        }
+        // Injecting our own Varnish ProxyClient instead of FOS'
+        $container->setParameter('fos_http_cache.proxy_client.varnish.class', 'EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish');
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,5 +1,4 @@
 parameters:
-    ezplatform.http_cache.proxy_client.varnish.class: EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish
     ezplatform.http_cache.controller.invalidatetoken.class: EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController
     ezplatform.http_cache.listener.vary_header.class: EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener
 
@@ -10,7 +9,7 @@ services:
 
     ezplatform.http_cache.proxy_client.varnish.factory:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishProxyClientFactory
-        arguments: ['@ezpublish.config.resolver', '@ezpublish.config.dynamic_setting.parser', '%ezplatform.http_cache.proxy_client.varnish.class%']
+        arguments: ['@ezpublish.config.resolver', '@ezpublish.config.dynamic_setting.parser', '%fos_http_cache.proxy_client.varnish.class%']
 
     ezplatform.http_cache.purge_client:
         alias: ezplatform.http_cache.purge_client_decorator


### PR DESCRIPTION
Fastly bundle is already changing the fos_http_cache.proxy_client.varnish.class parameter in a [kernelpass](https://github.com/ezsystems/ezplatform-http-cache-fastly/blob/master/src/DependencyInjection/Compiler/KernelPass.php#L19). So when we in ezplatform-http-cache opted to replace the whole parameter with a new one, Fasty's proxyclient was never used
