### PR TITLE
EZP-30358: HTTP Cache purge when ContentService\{Hide,Reveal}ContentSignal is emitted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.3@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.5@dev",
         "friendsofsymfony/http-cache-bundle": "^1.3.13",
         "symfony/symfony": "^2.8.40 || ^3.4.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.5@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.3@dev",
         "friendsofsymfony/http-cache-bundle": "^1.3.13",
         "symfony/symfony": "^2.8.40 || ^3.4.11"
     },

--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -167,6 +167,18 @@ services:
         tags:
             - { name: ezpublish.api.slot, signal: URLService\UpdateUrlSignal }
 
+    ezplatform.http_cache.signalslot.hide_content:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\HideContentSlot
+        parent: ezplatform.http_cache.signalslot.abstract_publish
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\HideContentSignal }
+
+    ezplatform.http_cache.signalslot.reveal_content:
+        class: EzSystems\PlatformHttpCacheBundle\SignalSlot\RevealContentSlot
+        parent: ezplatform.http_cache.signalslot.abstract_publish
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\RevealContentSignal }
+
     # Content Type
     ezplatform.http_cache.signalslot.assign_content_type_group:
         class: EzSystems\PlatformHttpCacheBundle\SignalSlot\ContentTypeService\AssignContentTypeGroupSlot

--- a/src/SignalSlot/HideContentSlot.php
+++ b/src/SignalSlot/HideContentSlot.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling HideContentSlot.
+ */
+class HideContentSlot extends AbstractPublishSlot
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\HideContentSignal;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContentId(Signal $signal)
+    {
+        return $signal->contentId;
+    }
+}

--- a/src/SignalSlot/RevealContentSlot.php
+++ b/src/SignalSlot/RevealContentSlot.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling RevealContentSlot.
+ */
+class RevealContentSlot extends AbstractPublishSlot
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\RevealContentSignal;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContentId(Signal $signal)
+    {
+        return $signal->contentId;
+    }
+}

--- a/tests/SignalSlot/AbstractSlotTest.php
+++ b/tests/SignalSlot/AbstractSlotTest.php
@@ -190,6 +190,8 @@ abstract class AbstractSlotTest extends TestCase
             Signal\ContentService\PublishVersionSignal::class,
             Signal\ContentService\DeleteRelationSignal::class,
             Signal\ContentService\DeleteVersionSignal::class,
+            Signal\ContentService\HideContentSignal::class,
+            Signal\ContentService\RevealContentSignal::class,
             Signal\LocationService\UpdateLocationSignal::class,
             Signal\LocationService\HideLocationSignal::class,
             Signal\LocationService\SwapLocationSignal::class,

--- a/tests/SignalSlot/AbstractSlotTest.php
+++ b/tests/SignalSlot/AbstractSlotTest.php
@@ -117,7 +117,7 @@ abstract class AbstractSlotTest extends TestCase
      */
     private function getAllSignals()
     {
-        return array(
+        $signals = array(
             Signal\URLAliasService\CreateUrlAliasSignal::class,
             Signal\URLAliasService\RemoveAliasesSignal::class,
             Signal\URLAliasService\CreateGlobalUrlAliasSignal::class,
@@ -190,8 +190,6 @@ abstract class AbstractSlotTest extends TestCase
             Signal\ContentService\PublishVersionSignal::class,
             Signal\ContentService\DeleteRelationSignal::class,
             Signal\ContentService\DeleteVersionSignal::class,
-            Signal\ContentService\HideContentSignal::class,
-            Signal\ContentService\RevealContentSignal::class,
             Signal\LocationService\UpdateLocationSignal::class,
             Signal\LocationService\HideLocationSignal::class,
             Signal\LocationService\SwapLocationSignal::class,
@@ -201,5 +199,15 @@ abstract class AbstractSlotTest extends TestCase
             Signal\LocationService\DeleteLocationSignal::class,
             Signal\LocationService\CopySubtreeSignal::class,
         );
+
+        if (class_exists('eZ\Publish\Core\SignalSlot\Signal\ContentService\HideContentSignal', false)) {
+            $signals[] = Signal\ContentService\HideContentSignal::class;
+        }
+
+        if (class_exists('eZ\Publish\Core\SignalSlot\Signal\ContentService\RevealContentSignal', false)) {
+            $signals[] = Signal\ContentService\RevealContentSignal::class;
+        }
+
+        return $signals;
     }
 }

--- a/tests/SignalSlot/HideContentSlotTest.php
+++ b/tests/SignalSlot/HideContentSlotTest.php
@@ -13,6 +13,10 @@ class HideContentSlotTest extends AbstractPublishSlotTest
 {
     public function createSignal()
     {
+        if (!class_exists('eZ\Publish\Core\SignalSlot\Signal\ContentService\HideContentSignal', false)) {
+            $this->markTestSkipped("eZ\Publish\Core\SignalSlot\Signal\ContentService\HideContentSignal doesn't exists");
+        }
+
         return new HideContentSignal([
             'contentId' => $this->contentId,
         ]);

--- a/tests/SignalSlot/HideContentSlotTest.php
+++ b/tests/SignalSlot/HideContentSlotTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\HideContentSignal;
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\HideContentSlot;
+
+class HideContentSlotTest extends AbstractPublishSlotTest
+{
+    public function createSignal()
+    {
+        return new HideContentSignal([
+            'contentId' => $this->contentId,
+        ]);
+    }
+
+    public function getSlotClass()
+    {
+        return HideContentSlot::class;
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return [HideContentSignal::class];
+    }
+}

--- a/tests/SignalSlot/RevealContentSlotTest.php
+++ b/tests/SignalSlot/RevealContentSlotTest.php
@@ -13,6 +13,10 @@ class RevealContentSlotTest extends AbstractPublishSlotTest
 {
     public function createSignal()
     {
+        if (!class_exists('eZ\Publish\Core\SignalSlot\Signal\ContentService\RevealContentSignal', false)) {
+            $this->markTestSkipped("eZ\Publish\Core\SignalSlot\Signal\ContentService\RevealContentSignal doesn't exists");
+        }
+
         return new RevealContentSignal([
             'contentId' => $this->contentId,
         ]);

--- a/tests/SignalSlot/RevealContentSlotTest.php
+++ b/tests/SignalSlot/RevealContentSlotTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\RevealContentSignal;
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\RevealContentSlot;
+
+class RevealContentSlotTest extends AbstractPublishSlotTest
+{
+    public function createSignal()
+    {
+        return new RevealContentSignal([
+            'contentId' => $this->contentId,
+        ]);
+    }
+
+    public function getSlotClass()
+    {
+        return RevealContentSlot::class;
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return [RevealContentSignal::class];
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30358

## Description

Implementation of HTTP cache purge when `ContentService\HideContentSignal`/`ContentService\RevealContentSignal` is emitted. 
