### PR TITLE
EZP-30554: Purge several keys at once to simplify debug & reduce round trips

### DIFF
--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -9,7 +9,7 @@ They work in a similar way as [persistence cache tags in eZ Platform v2](https:/
 
 It works across all supported proxies _(see ["drivers"](drivers.md))_ by eZ Platform:
 - Symfony Proxy _(PHP based for single server usage, primarily for smaller web sites)_
-- [Varnish](https://varnish-cache.org/) with [xkey module](https://github.com/varnish/varnish-modules) _or_ [Varnish Plus](https://www.varnish-software.com/products/varnish-plus/) _(High performance reverse proxy)_
+- [Varnish](https://varnish-cache.org/) with [xkey module (0.10.2+)](https://github.com/varnish/varnish-modules) _or_ [Varnish Plus](https://www.varnish-software.com/products/varnish-plus/) _(High performance reverse proxy)_
 - [Fastly](https://www.fastly.com/) _(High performance reverse proxy, originally based on Varnish, worldwide as a CDN, driver available in eZ Platform Enterprise)_
 
 _In order to support several repositories on one installation, tags will be prefixed by

--- a/docs/varnish/README.md
+++ b/docs/varnish/README.md
@@ -5,6 +5,7 @@ Prerequisites
 -------------
 * A working Varnish 4.1 and higher setup with xkey module installed
   * _As of eZ Platform 2.5LTS the requirement is Varnish 5.1 (6.0LTS recommended and what we mainly test against)_
+  * ezplatform-http-cache 0.9+ requires varnish-modules 0.10.2 or higher, use 0.8 if you need to use varnish-modules 0.9
 * Varnish Plus comes with xkey out of the box and can also be used.
 
 Recommended VCL base files
@@ -23,7 +24,7 @@ For tuning the VCL further to you needs, see the following relevant examples:
 
 Example installation on Debian/Ubuntu:
 --------------------------------------
-Starting with Debian 9 and Ubuntu 16.10 installation of `xkey` VMOD is greatly
+Starting with Debian 9 and Ubuntu 18.04 installation of `xkey` VMOD is greatly
 simplified as new [varnish-modules](https://github.com/varnish/varnish-modules) package now exists.
 
 Install:

--- a/docs/varnish/vcl/varnish4.vcl
+++ b/docs/varnish/vcl/varnish4.vcl
@@ -1,6 +1,6 @@
 // Varnish VCL for:
 // - Varnish 4.1 or higher (4.1LTS or 6.0LTS recommended, and is what we mainly test against)
-//   - Varnish xkey vmod (via varnish-modules package, or via Varnish Plus)
+//   - Varnish xkey vmod (via varnish-modules package 0.10.2 or higher, or via Varnish Plus)
 // - eZ Platform 1.13 with ezplatform-http-cache bundle
 //
 // Make sure to at least adjust default parameters.yml, defaults there reflect our testing needs with docker.

--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -1,6 +1,6 @@
 // Varnish VCL for:
 // - Varnish 5.1 or higher (6.0LTS recommended, and is what we mainly test against)
-//   - Varnish xkey vmod (via varnish-modules package 0,10.2 or higher, or via Varnish Plus)
+//   - Varnish xkey vmod (via varnish-modules package 0.10.2 or higher, or via Varnish Plus)
 // - eZ Platform 2.5LTS or higher with ezplatform-http-cache (this) bundle
 //
 // Make sure to at least adjust default parameters.yml, defaults there reflect our testing needs with docker.

--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -1,6 +1,6 @@
 // Varnish VCL for:
 // - Varnish 5.1 or higher (6.0LTS recommended, and is what we mainly test against)
-//   - Varnish xkey vmod (via varnish-modules package, or via Varnish Plus)
+//   - Varnish xkey vmod (via varnish-modules package 0,10.2 or higher, or via Varnish Plus)
 // - eZ Platform 2.5LTS or higher with ezplatform-http-cache (this) bundle
 //
 // Make sure to at least adjust default parameters.yml, defaults there reflect our testing needs with docker.

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -37,10 +37,6 @@ class HttpCacheConfigParser implements ParserInterface
                     ->scalarNode('varnish_invalidate_token')
                         ->info('Optional: Varnish Invalidation token for purge')
                         ->defaultNull()
-                    ->end()
-                    ->scalarNode('varnish_bulk_purge')
-                        ->info('If purge should happen in bulk or not (if on varnish-module 0.9.x you should disable this)')
-                        ->defaultTrue()
                     ->end();
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
@@ -62,10 +58,6 @@ class HttpCacheConfigParser implements ParserInterface
 
         if (isset($scopeSettings['http_cache']['varnish_invalidate_token'])) {
             $contextualizer->setContextualParameter('http_cache.varnish_invalidate_token', $currentScope, $scopeSettings['http_cache']['varnish_invalidate_token']);
-        }
-
-        if (isset($scopeSettings['http_cache']['varnish_bulk_purge'])) {
-            $contextualizer->setContextualParameter('http_cache.varnish_bulk_purge', $currentScope, $scopeSettings['http_cache']['varnish_bulk_purge']);
         }
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -37,6 +37,10 @@ class HttpCacheConfigParser implements ParserInterface
                     ->scalarNode('varnish_invalidate_token')
                         ->info('Optional: Varnish Invalidation token for purge')
                         ->defaultNull()
+                    ->end()
+                    ->scalarNode('varnish_bulk_purge')
+                        ->info('If purge should happen in bulk or not (if on varnish-module 0.9.x you should disable this)')
+                        ->defaultTrue()
                     ->end();
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
@@ -58,6 +62,10 @@ class HttpCacheConfigParser implements ParserInterface
 
         if (isset($scopeSettings['http_cache']['varnish_invalidate_token'])) {
             $contextualizer->setContextualParameter('http_cache.varnish_invalidate_token', $currentScope, $scopeSettings['http_cache']['varnish_invalidate_token']);
+        }
+
+        if (isset($scopeSettings['http_cache']['varnish_bulk_purge'])) {
+            $contextualizer->setContextualParameter('http_cache.varnish_bulk_purge', $currentScope, $scopeSettings['http_cache']['varnish_bulk_purge']);
         }
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -56,8 +56,7 @@ class VarnishPurgeClient implements PurgeClientInterface
         $headers = $this->getPurgeHeaders();
         $chunkSize = $this->determineTagsPerHeader($tags);
 
-        // NB! This requries varnish-moduls 0.10.2 or higher, 0.9.x only supported purging one tag at a time
-        // If you need support for varnish-moduls 0.9.x, use ezplatform-http-cache 0.8.x
+        // NB! This requries varnish-modules 0.10.2, if you need support for varnish-moduls 0.9.x, use ezplatform-http-cache 0.8.x
         foreach (array_chunk($tags, $chunkSize) as $tagchunk) {
             $headers['key'] = implode(' ', $tagchunk);
             $this->cacheManager->invalidatePath(

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -56,7 +56,7 @@ class VarnishPurgeClient implements PurgeClientInterface
         $headers = $this->getPurgeHeaders();
         $chunkSize = $this->determineTagsPerHeader($tags);
 
-        // NB! This requries varnish-modules 0.10.2, if you need support for varnish-moduls 0.9.x, use ezplatform-http-cache 0.8.x
+        // NB! This requries varnish-modules 0.10.2, if you need support for varnish-modules 0.9.x, use ezplatform-http-cache 0.8.x
         foreach (array_chunk($tags, $chunkSize) as $tagchunk) {
             $headers['key'] = implode(' ', $tagchunk);
             $this->cacheManager->invalidatePath(

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -77,10 +77,10 @@ class VarnishPurgeClientTest extends TestCase
             ->willReturn(true);
 
         $this->configResolver
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(2))
             ->method('getParameter')
-            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM], ['http_cache.varnish_bulk_purge'])
-            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], null, true);
+            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM])
+            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], null);
 
         $this->purgeClient->purge($locationId);
     }
@@ -103,10 +103,10 @@ class VarnishPurgeClientTest extends TestCase
             ->willReturn(true);
 
         $this->configResolver
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(2))
             ->method('getParameter')
-            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM], ['http_cache.varnish_bulk_purge'])
-            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], $token, false);
+            ->withConsecutive(['http_cache.purge_servers'], [VarnishPurgeClient::INVALIDATE_TOKEN_PARAM])
+            ->willReturnOnConsecutiveCalls(['https://varnishpurgehost'], $token);
 
         $this->purgeClient->purge($locationId);
     }
@@ -133,12 +133,6 @@ class VarnishPurgeClientTest extends TestCase
             ->method('getParameter')
             ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
             ->willReturn(null);
-
-        $this->configResolver
-            ->expects($this->at(3))
-            ->method('getParameter')
-            ->with('http_cache.varnish_bulk_purge')
-            ->willReturn(true);
 
         $keys = array_map(static function ($id) {
             return "location-$id";
@@ -179,12 +173,6 @@ class VarnishPurgeClientTest extends TestCase
             ->method('getParameter')
             ->with(VarnishPurgeClient::INVALIDATE_TOKEN_PARAM)
             ->willReturn($token);
-
-        $this->configResolver
-            ->expects($this->at(3))
-            ->method('getParameter')
-            ->with('http_cache.varnish_bulk_purge')
-            ->willReturn(true);
 
         $keys = array_map(static function ($id) {
             return "location-$id";


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30554](https://jira.ez.no/browse/EZP-30554)
| **Type**           | Improvement
| **Target version** | `0.9`
| **BC breaks**      | no
| **Doc needed**     | _maybe_

As of 2.5LTS we require Varnish 5.1 or higher, meaning we can take advantage of varnish-modules 0.10+ support for [several keys in header while purging](https://github.com/varnish/varnish-modules/blob/master/docs/vmod_xkey.rst#example). In order to:
- Simplify Varnish debugging when checking purge requests
- Reduce rountrips on between web server and varnish for purges

Given the package is also allowed to be used on 1.13, which supports Varnish 4.x. Should we ❓ 
- A. Expose a setting for this as currently is the case in this PR
- B. Avoid complexity of a temprary setting, and rather tell 1.13 + Varnish 4.x users to use ezplatform-http-cache 0.8.x.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
