### PR TITLE
[WIP] EZP-30562: As an Administrator I would like to use short HTTP cache tags

### DIFF
--- a/spec/DependencyInjection/Compiler/KernelPassSpec.php
+++ b/spec/DependencyInjection/Compiler/KernelPassSpec.php
@@ -10,12 +10,12 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class KernelPassSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(KernelPass::class);
     }
 
-    function it_disables_the_kernels_httpcache_services(ContainerBuilder $container, Definition $cacheClearer, Definition $hashGenerator)
+    public function it_disables_the_kernels_httpcache_services(ContainerBuilder $container, Definition $cacheClearer, Definition $hashGenerator)
     {
         $container->getAlias('ezpublish.http_cache.purge_client')->willReturn('some_random_id');
         $container->hasAlias('ezpublish.http_cache.purger')->willReturn(true);
@@ -44,14 +44,14 @@ class KernelPassSpec extends ObjectBehavior
                 'ezpublish.http_cache.witness_service',
                 'ezpublish.http_cache.purger.some_purger',
                 'ezpublish.http_cache.purger.some_other_purger',
-                'witness_service'
-            ]
+                'witness_service',
+            ],
         ]);
         $cacheClearer->setArguments([
             [
                 'ezpublish.http_cache.witness_service',
-                'witness_service'
-            ]
+                'witness_service',
+            ],
         ])->shouldBeCalled();
 
         $container->hasDefinition('ezpublish.user.identity_definer.role_id')->willReturn(true);
@@ -62,13 +62,13 @@ class KernelPassSpec extends ObjectBehavior
                 $ref1 = new Reference('ezplatform.http_cache.user_context_provider.role_identify'),
                 $ref2 = new Reference('ezpublish.user.hash_generator'),
                 new Reference('ezpublish.user.identity_definer.role_id'),
-            ]
+            ],
         ]);
         $hashGenerator->setArguments([
             [
                 $ref1,
                 $ref2,
-            ]
+            ],
         ])->shouldBeCalled();
 
         $container->getParameter('ezpublish.http_cache.purge_type')->shouldBeCalled();

--- a/spec/EventSubscriber/UserContextSubscriberSpec.php
+++ b/spec/EventSubscriber/UserContextSubscriberSpec.php
@@ -25,7 +25,7 @@ class UserContextSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($prefixService, 'xkey');
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(UserContextSubscriber::class);
     }

--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -6,7 +6,6 @@
 namespace spec\EzSystems\PlatformHttpCacheBundle\Handler;
 
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
-
 use EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix;
 use FOS\HttpCacheBundle\CacheManager;
 use PhpSpec\ObjectBehavior;

--- a/spec/RepositoryTagPrefixSpec.php
+++ b/spec/RepositoryTagPrefixSpec.php
@@ -14,7 +14,7 @@ class RepositoryTagPrefixSpec extends ObjectBehavior
         $this->beConstructedWith($resolver, ['default' => [], 'intra' => []]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(RepositoryTagPrefix::class);
     }

--- a/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
+++ b/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
@@ -6,7 +6,6 @@ use EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseC
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use FOS\HttpCache\Handler\TagHandler;
 
 class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
 {

--- a/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
+++ b/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
@@ -4,14 +4,16 @@ namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use FOS\HttpCache\Handler\TagHandler;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class ContentInfoTaggerSpec extends ObjectBehavior
 {
-    public function let(TagHandler $tagHandler)
+    public function let(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
-        $this->beConstructedWith($tagHandler);
+        $this->beConstructedWith($tagHandler, $tagProvider);
     }
 
     public function it_is_initializable()
@@ -19,28 +21,48 @@ class ContentInfoTaggerSpec extends ObjectBehavior
         $this->shouldHaveType(ContentInfoTagger::class);
     }
 
-    public function it_ignores_non_content_info(TagHandler $tagHandler)
+    public function it_ignores_non_content_info(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
         $this->tag(null);
+
+        $tagProvider->getTagForContentId()->shouldNotHaveBeenCalled();
+        $tagProvider->getTagForContentTypeId()->shouldNotHaveBeenCalled();
+        $tagProvider->getTagForLocationId()->shouldNotHaveBeenCalled();
 
         $tagHandler->addTags()->shouldNotHaveBeenCalled();
     }
 
-    public function it_tags_with_content_and_content_type_id(TagHandler $tagHandler)
+    public function it_tags_with_content_and_content_type_id(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
         $value = new ContentInfo(['id' => 123, 'contentTypeId' => 987]);
+
+        $tagProvider->getTagForContentId(Argument::exact($value->id))->willReturn('content-123');
+        $tagProvider->getTagForContentTypeId(Argument::exact($value->contentTypeId))->willReturn('content-type-987');
 
         $this->tag($value);
 
         $tagHandler->addTags(['content-123', 'content-type-987'])->shouldHaveBeenCalled();
     }
 
-    public function it_tags_with_location_id_if_one_is_set(TagHandler $tagHandler)
+    public function it_tags_with_location_id_if_one_is_set(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
-        $value = new ContentInfo(['mainLocationId' => 456]);
+        $this->beConstructedWith($tagHandler, $tagProvider);
+
+        $value = new ContentInfo(
+            [
+                'id' => 123,
+                'mainLocationId' => 456,
+                'contentTypeId' => 987,
+            ]
+        );
+
+        $tagProvider->getTagForContentId(Argument::exact($value->id))->willReturn('content-123');
+        $tagProvider->getTagForContentTypeId(Argument::exact($value->contentTypeId))->willReturn('content-type-987');
+        $tagProvider->getTagForLocationId(Argument::exact($value->mainLocationId))->willReturn('location-456');
 
         $this->tag($value);
 
+        $tagHandler->addTags(['content-123', 'content-type-987'])->shouldHaveBeenCalled();
         $tagHandler->addTags(['location-456'])->shouldHaveBeenCalled();
     }
 }

--- a/spec/ResponseTagger/Value/LocationTaggerSpec.php
+++ b/spec/ResponseTagger/Value/LocationTaggerSpec.php
@@ -5,15 +5,16 @@ namespace spec\EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use FOS\HttpCache\Handler\TagHandler;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class LocationTaggerSpec extends ObjectBehavior
 {
-    public function let(TagHandler $tagHandler)
+    public function let(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
-        $this->beConstructedWith($tagHandler);
+        $this->beConstructedWith($tagHandler, $tagProvider);
     }
 
     public function it_is_initializable()
@@ -28,29 +29,42 @@ class LocationTaggerSpec extends ObjectBehavior
         $tagHandler->addTags(Argument::any())->shouldNotHaveBeenCalled();
     }
 
-    public function it_tags_with_location_id_if_not_main_location(TagHandler $tagHandler)
+    public function it_tags_with_location_id_if_not_main_location(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
-        $value = new Location(['id' => 123, 'contentInfo' => new ContentInfo(['mainLocationId' => 321])]);
+        $value = new Location(['id' => 123, 'parentLocationId' => 2, 'contentInfo' => new ContentInfo(['mainLocationId' => 321])]);
+
+        $tagProvider->getTagForLocationId(123)->willReturn('location-123');
+        $tagProvider->getTagForParentId(2)->willReturn('parent-2');
+
         $this->tag($value);
 
         $tagHandler->addTags(['location-123'])->shouldHaveBeenCalled();
     }
 
-    public function it_tags_with_parent_location_id(TagHandler $tagHandler)
+    public function it_tags_with_parent_location_id(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
-        $value = new Location(['parentLocationId' => 123, 'contentInfo' => new ContentInfo()]);
+        $value = new Location(['id' => 2, 'parentLocationId' => 123, 'contentInfo' => new ContentInfo(['mainLocationId' => 2])]);
+
+        $tagProvider->getTagForParentId(123)->willReturn('parent-123');
 
         $this->tag($value);
 
         $tagHandler->addTags(['parent-123'])->shouldHaveBeenCalled();
     }
 
-    public function it_tags_with_path_items(TagHandler $tagHandler)
+    public function it_tags_with_path_items(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
-        $value = new Location(['pathString' => '/1/2/123', 'contentInfo' => new ContentInfo()]);
+        $value = new Location(['id' => 12, 'parentLocationId' => 2, 'pathString' => '/1/2/123', 'contentInfo' => new ContentInfo()]);
+
+        $tagProvider->getTagForLocationId(12)->willReturn('location-12');
+        $tagProvider->getTagForParentId(2)->willReturn('location-12');
+        $tagProvider->getTagForPathId(1)->willReturn('path-1');
+        $tagProvider->getTagForPathId(2)->willReturn('path-2');
+        $tagProvider->getTagForPathId(123)->willReturn('path-123');
 
         $this->tag($value);
 
+        $tagHandler->addTags(['location-12'])->shouldHaveBeenCalled();
         $tagHandler->addTags(['path-1', 'path-2', 'path-123'])->shouldHaveBeenCalled();
     }
 }

--- a/spec/TagProvider/TagProviderSpec.php
+++ b/spec/TagProvider/TagProviderSpec.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace spec\EzSystems\PlatformHttpCacheBundle\TagProvider;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProvider;
+use PhpSpec\ObjectBehavior;
+
+class TagProviderSpec extends ObjectBehavior
+{
+    const TAGS_MAP = [
+        'short' => [
+            'location' => 'l',
+            'content' => 'c',
+            'contentType' => 'ct',
+            'contentVersions' => 'cv',
+            'parent' => 'p',
+            'relation' => 'r',
+            'relationLocation' => 'rl',
+            'path' => 'pa',
+            'type' => 't',
+            'typeGroup' => 'tg',
+            'section' => 's',
+            'all' => 'ea'
+        ],
+        'long' => [
+            'location' => 'location',
+            'content' => 'content',
+            'contentType' => 'content-type',
+            'contentVersions' => 'content-versions',
+            'parent' => 'parent',
+            'relation' => 'relation',
+            'relationLocation' => 'relation-location',
+            'path' => 'path',
+            'type' => 'type',
+            'typeGroup' => 'type-group',
+            'section' => 'section',
+            'all' => 'ez-all',
+        ]
+    ];
+
+    public function let(ConfigResolverInterface $configResolver)
+    {
+        $this->beConstructedWith($configResolver, self::TAGS_MAP, 'ez-user-context-hash');
+        $configResolver->getParameter('http_cache.tag_format')->willReturn('short');
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(TagProvider::class);
+    }
+
+    public function it_provides_tag_for_location_id()
+    {
+        $locationId = 12;
+        $this->getTagForLocationId($locationId)->shouldReturn('l-' . $locationId);
+    }
+
+    public function it_provides_tag_for_content_id()
+    {
+        $contentId = 12;
+        $this->getTagForContentId($contentId)->shouldReturn('c-' . $contentId);
+    }
+
+    public function it_provides_tag_for_content_type_id()
+    {
+        $contentTypeId = 12;
+        $this->getTagForContentTypeId($contentTypeId)->shouldReturn('ct-' . $contentTypeId);
+    }
+
+    public function it_provides_tag_for_content_versions()
+    {
+        $versions = 12;
+        $this->getTagForContentVersions($versions)->shouldReturn('cv-' . $versions);
+    }
+
+    public function it_provides_tag_for_parent_id()
+    {
+        $parentId = 12;
+        $this->getTagForParentId($parentId)->shouldReturn('p-' . $parentId);
+    }
+
+    public function it_provides_tag_for_relation_id()
+    {
+        $relationId = 12;
+        $this->getTagForRelationId($relationId)->shouldReturn('r-' . $relationId);
+    }
+
+    public function it_provides_tag_for_relation_location_id()
+    {
+        $locationId = 12;
+        $this->getTagForRelationLocationId($locationId)->shouldReturn('rl-' . $locationId);
+    }
+
+    public function it_provides_tag_for_path_id()
+    {
+        $locationId = 12;
+        $this->getTagForPathId($locationId)->shouldReturn('pa-' . $locationId);
+    }
+
+    public function it_provides_tag_for_section_id()
+    {
+        $sectionId = 12;
+        $this->getTagForSectionId($sectionId)->shouldReturn('s-' . $sectionId);
+    }
+
+    public function it_provides_tag_for_type_id()
+    {
+        $typeId = 12;
+        $this->getTagForTypeId($typeId)->shouldReturn('t-' . $typeId);
+    }
+
+    public function it_provides_tag_for_type_group_id()
+    {
+        $typeGroupId = 12;
+        $this->getTagForTypeGroupId($typeGroupId)->shouldReturn('tg-' . $typeGroupId);
+    }
+
+    public function it_provides_tag_for_all()
+    {
+        $this->getTagForAll()->shouldReturn('ea');
+    }
+
+    public function it_provides_tag_for_user_context_hash()
+    {
+        $this->getTagForUserContextHash()->shouldReturn('ez-user-context-hash');
+    }
+}

--- a/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -37,6 +37,14 @@ class HttpCacheConfigParser implements ParserInterface
                     ->scalarNode('varnish_invalidate_token')
                         ->info('Optional: Varnish Invalidation token for purge')
                         ->defaultNull()
+                    ->end()
+                    ->scalarNode('tag_format')
+                        ->info('Choose whether to use short or long tags')
+                        ->defaultValue('short')
+                        ->validate()
+                            ->ifNotInArray(['short', 'long'])
+                            ->thenInvalid('Invalid tag format')
+                        ->end()
                     ->end();
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {
@@ -58,6 +66,10 @@ class HttpCacheConfigParser implements ParserInterface
 
         if (isset($scopeSettings['http_cache']['varnish_invalidate_token'])) {
             $contextualizer->setContextualParameter('http_cache.varnish_invalidate_token', $currentScope, $scopeSettings['http_cache']['varnish_invalidate_token']);
+        }
+
+        if (isset($scopeSettings['http_cache']['tag_format'])) {
+            $contextualizer->setContextualParameter('http_cache.tag_format', $currentScope, $scopeSettings['http_cache']['tag_format']);
         }
 
         foreach ($this->getExtraConfigParsers() as $extraConfigParser) {

--- a/src/PurgeClient/LocalPurgeClient.php
+++ b/src/PurgeClient/LocalPurgeClient.php
@@ -9,6 +9,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
 
 use EzSystems\PlatformHttpCacheBundle\RequestAwarePurger;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -22,9 +23,15 @@ class LocalPurgeClient implements PurgeClientInterface
      */
     protected $cacheStore;
 
-    public function __construct(RequestAwarePurger $cacheStore)
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface
+     */
+    private $tagProvider;
+
+    public function __construct(RequestAwarePurger $cacheStore, TagProviderInterface $tagProvider)
     {
         $this->cacheStore = $cacheStore;
+        $this->tagProvider = $tagProvider;
     }
 
     public function purge($tags)
@@ -35,7 +42,7 @@ class LocalPurgeClient implements PurgeClientInterface
 
         $tags = array_map(
             function ($tag) {
-                return is_numeric($tag) ? 'location-' . $tag : $tag;
+                return is_numeric($tag) ? $this->tagProvider->getTagForLocationId($tag) : $tag;
             },
             (array)$tags
         );

--- a/src/PurgeClient/TagsConverterDecorator.php
+++ b/src/PurgeClient/TagsConverterDecorator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
+
+use EzSystems\PlatformHttpCacheBundle\TagProvider\ShortToLongTagConverter;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
+
+class TagsConverterDecorator implements PurgeClientInterface
+{
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface
+     */
+    private $purgeClient;
+
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface
+     */
+    private $tagProvider;
+
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\TagProvider\ShortToLongTagConverter
+     */
+    private $tagConverter;
+
+    public function __construct(
+        PurgeClientInterface $purgeClient,
+        TagProviderInterface $tagProvider,
+        ShortToLongTagConverter $tagMapper
+    ) {
+        $this->purgeClient = $purgeClient;
+        $this->tagConverter = $tagMapper;
+        $this->tagProvider = $tagProvider;
+    }
+
+    public function purge($tags)
+    {
+        $tags = $this->map($tags);
+        $this->purgeClient->purge($tags);
+    }
+
+    public function purgeAll()
+    {
+        $this->purgeClient->purgeAll();
+    }
+
+    private function map(array $tags)
+    {
+        $userContextHash = $this->tagProvider->getTagForUserContextHash();
+        $mappedTags = [];
+
+        foreach (array_unique($tags) as $tag) {
+            // If tag is numeric, do nothing. It's going to be handled properly in the next decorator.
+            if (is_numeric($tag)) {
+                continue;
+            }
+
+            // If tag is context hash, do nothing.
+            if ($tag === $userContextHash) {
+                continue;
+            }
+
+            $mappedTags[] = $this->tagConverter->convert($tag);
+        }
+
+        return array_unique(array_merge($tags, $mappedTags));
+    }
+}

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -3,3 +3,33 @@ parameters:
     ezplatform.http_cache.tags.header: 'xkey'
     ezplatform.http_cache.invalidate_token.ttl: 86400
     ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
+    ezplatform.http_cache.user_context_hash_tag: 'ez-user-context-hash'
+
+    ezplatform.http_cache.tags_map:
+        short:
+            location: 'l'
+            content: 'c'
+            contentType: 'ct'
+            contentVersions: 'cv'
+            parent: 'p'
+            relation: 'r'
+            relationLocation: 'rl'
+            path: 'pa'
+            type: 't'
+            typeGroup: 'tg'
+            section: 's'
+            all: 'ea'
+        long:
+            location: 'location'
+            content: 'content'
+            contentType: 'content-type'
+            contentVersions: 'content-versions'
+            parent: 'parent'
+            relation: 'relation'
+            relationLocation: 'relation-location'
+            path: 'path'
+            type: 'type'
+            typeGroup: 'type-group'
+            section: 'section'
+            all: 'ez-all'
+

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -87,6 +87,7 @@ services:
 
     ezplatform.http_cache.tag_provider:
         class: "%ezplatform.http_cache.tag_provider.class%"
+        lazy: true
         arguments:
             - '@ezpublish.config.resolver.chain'
             - '%ezplatform.http_cache.tags_map%'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,6 +1,7 @@
 parameters:
     ezplatform.http_cache.controller.invalidatetoken.class: EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController
     ezplatform.http_cache.listener.vary_header.class: EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener
+    ezplatform.http_cache.tag_provider.class: EzSystems\PlatformHttpCacheBundle\TagProvider\TagProvider
 
 services:
     ezplatform.http_cache.cache_manager:
@@ -11,12 +12,17 @@ services:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishProxyClientFactory
         arguments: ['@ezpublish.config.resolver', '@ezpublish.config.dynamic_setting.parser', '%fos_http_cache.proxy_client.varnish.class%']
 
+    ezplatform.http_cache.tags_converter_decorator:
+        class: EzSystems\PlatformHttpCacheBundle\PurgeClient\TagsConverterDecorator
+        decorates: ezplatform.http_cache.purge_client_decorator
+        arguments: ['@ezplatform.http_cache.tags_converter_decorator.inner', '@ezplatform.http_cache.tag_provider', '@ezplatform.http_cache.tag_converter']
+
     ezplatform.http_cache.purge_client:
         alias: ezplatform.http_cache.purge_client_decorator
 
     ezplatform.http_cache.purge_client_decorator:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\RepositoryPrefixDecorator
-        arguments: ['@ezplatform.http_cache.purge_client_internal', '@ezplatform.http_cache.repository_tag_prefix']
+        arguments: ['@ezplatform.http_cache.purge_client_internal', '@ezplatform.http_cache.repository_tag_prefix', '@ezplatform.http_cache.tag_provider']
 
     ezplatform.http_cache.purge_client_internal:
         alias: ezplatform.http_cache.purge_client.local
@@ -26,13 +32,14 @@ services:
         arguments:
             - '@ezplatform.http_cache.cache_manager'
             - '@ezpublish.config.resolver'
+            - '@ezplatform.http_cache.tag_provider'
         tags:
             - {name: ezplatform.http_cache.purge_client, purge_type: http}
             - {name: ezplatform.http_cache.purge_client, purge_type: varnish}
 
     ezplatform.http_cache.purge_client.local:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient
-        arguments: ['@ezplatform.http_cache.store']
+        arguments: ['@ezplatform.http_cache.store', '@ezplatform.http_cache.tag_provider']
         tags:
             - {name: ezplatform.http_cache.purge_client, purge_type: local}
 
@@ -41,7 +48,9 @@ services:
 
     ezplatform.http_cache.tag_aware_store:
         class: EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore
-        arguments: ['%ezplatform.http_cache.store.root%']
+        arguments:
+            - '%ezplatform.http_cache.store.root%'
+            - '@ezplatform.http_cache.tag_provider'
 
     ezplatform.http_cache.fos_tag_handler.xkey:
         class: EzSystems\PlatformHttpCacheBundle\Handler\TagHandler
@@ -75,3 +84,15 @@ services:
         class: EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix
         # Use config resolver to be able to lazy load reading SA setting "repository" to avoid scope change issues
         arguments: ["@ezpublish.config.resolver", '%ezpublish.repositories%']
+
+    ezplatform.http_cache.tag_provider:
+        class: "%ezplatform.http_cache.tag_provider.class%"
+        arguments:
+            - '@ezpublish.config.resolver.chain'
+            - '%ezplatform.http_cache.tags_map%'
+            - '%ezplatform.http_cache.user_context_hash_tag%'
+
+    ezplatform.http_cache.tag_converter:
+        class: EzSystems\PlatformHttpCacheBundle\TagProvider\ShortToLongTagConverter
+        arguments: ['%ezplatform.http_cache.tags_map%']
+

--- a/src/Resources/config/slot.yml
+++ b/src/Resources/config/slot.yml
@@ -2,11 +2,11 @@ services:
     # AbstractSlot or AbstractContentSlot
     ezplatform.http_cache.signalslot.abstract:
         abstract: true
-        arguments: ["@ezplatform.http_cache.purge_client"]
+        arguments: ["@ezplatform.http_cache.purge_client", '@ezplatform.http_cache.tag_provider']
 
     ezplatform.http_cache.signalslot.abstract_publish:
         abstract: true
-        arguments: ["@ezplatform.http_cache.purge_client", "@ezpublish.spi.persistence.cache.locationHandler"]
+        arguments: ["@ezplatform.http_cache.purge_client", "@ezplatform.http_cache.tag_provider", "@ezpublish.spi.persistence.cache.locationHandler"]
 
     # Content
     ezplatform.http_cache.signalslot.copy_content:

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -10,13 +10,13 @@ services:
 
     ezplatform.x_location_id.response_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\XLocationIdResponseSubscriber
-        arguments: ['@fos_http_cache.handler.tag_handler', '@ezpublish.api.repository']
+        arguments: ['@fos_http_cache.handler.tag_handler', '@ezpublish.api.repository', '@ezplatform.http_cache.tag_provider']
         tags:
             - { name: kernel.event_subscriber }
 
     ezplatform.rest_cache_tagging.view_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\RestKernelViewSubscriber
-        arguments: ['@fos_http_cache.handler.tag_handler']
+        arguments: ['@fos_http_cache.handler.tag_handler', '@ezplatform.http_cache.tag_provider']
         tags:
             - { name: kernel.event_subscriber }
 
@@ -64,7 +64,7 @@ services:
     # ResponseTagger value handlers
     ezplatform.view_cache.response_tagger.abstract_value:
         abstract: true
-        arguments: ['@fos_http_cache.handler.tag_handler']
+        arguments: ['@fos_http_cache.handler.tag_handler', '@ezplatform.http_cache.tag_provider']
 
     ezplatform.view_cache.response_tagger.content_info:
         class: EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger
@@ -81,6 +81,6 @@ services:
     # Twig
     ezplatform.view_cache.twig_extension:
         class: EzSystems\PlatformHttpCacheBundle\Twig\ContentTaggingExtension
-        arguments: ['@ezplatform.view_cache.response_tagger.dispatcher']
+        arguments: ['@ezplatform.view_cache.response_tagger.dispatcher', '@ezplatform.http_cache.tag_provider', '@ezplatform.http_cache.fos_tag_handler.xkey']
         tags:
             - {name: twig.extension}

--- a/src/ResponseTagger/Value/AbstractValueTagger.php
+++ b/src/ResponseTagger/Value/AbstractValueTagger.php
@@ -3,6 +3,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
 
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use FOS\HttpCache\Handler\TagHandler;
 
 abstract class AbstractValueTagger implements ResponseTagger
@@ -10,8 +11,12 @@ abstract class AbstractValueTagger implements ResponseTagger
     /** @var TagHandler */
     protected $tagHandler;
 
-    public function __construct(TagHandler $tagHandler)
+    /** @var TagProviderInterface */
+    protected $tagProvider;
+
+    public function __construct(TagHandler $tagHandler, TagProviderInterface $tagProvider)
     {
         $this->tagHandler = $tagHandler;
+        $this->tagProvider = $tagProvider;
     }
 }

--- a/src/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/ResponseTagger/Value/ContentInfoTagger.php
@@ -12,10 +12,13 @@ class ContentInfoTagger extends AbstractValueTagger
             return $this;
         }
 
-        $this->tagHandler->addTags(['content-' . $value->id, 'content-type-' . $value->contentTypeId]);
+        $this->tagHandler->addTags([
+            $this->tagProvider->getTagForContentId($value->id),
+            $this->tagProvider->getTagForContentTypeId($value->contentTypeId),
+        ]);
 
         if ($value->mainLocationId) {
-            $this->tagHandler->addTags(['location-' . $value->mainLocationId]);
+            $this->tagHandler->addTags([$this->tagProvider->getTagForLocationId($value->mainLocationId)]);
         }
     }
 }

--- a/src/ResponseTagger/Value/LocationTagger.php
+++ b/src/ResponseTagger/Value/LocationTagger.php
@@ -13,14 +13,14 @@ class LocationTagger extends AbstractValueTagger
         }
 
         if ($value->id !== $value->contentInfo->mainLocationId) {
-            $this->tagHandler->addTags(['location-' . $value->id]);
+            $this->tagHandler->addTags([$this->tagProvider->getTagForLocationId($value->id)]);
         }
 
-        $this->tagHandler->addTags(['parent-' . $value->parentLocationId]);
+        $this->tagHandler->addTags([$this->tagProvider->getTagForParentId($value->parentLocationId)]);
         $this->tagHandler->addTags(
             array_map(
                 function ($pathItem) {
-                    return 'path-' . $pathItem;
+                    return $this->tagProvider->getTagForPathId($pathItem);
                 },
                 $value->path
             )

--- a/src/SignalSlot/AbstractContentSlot.php
+++ b/src/SignalSlot/AbstractContentSlot.php
@@ -33,25 +33,25 @@ abstract class AbstractContentSlot extends AbstractSlot
 
         if (isset($signal->contentId)) {
             // self in all forms (also without locations)
-            $tags[] = 'content-' . $signal->contentId;
+            $tags[] = $this->tagProvider->getTagForContentId($signal->contentId);
             // reverse relations
-            $tags[] = 'relation-' . $signal->contentId;
+            $tags[] = $this->tagProvider->getTagForRelationId($signal->contentId);
         }
 
         if (isset($signal->locationId)) {
             // self
-            $tags[] = 'location-' . $signal->locationId;
+            $tags[] = $this->tagProvider->getTagForLocationId($signal->locationId);
             // direct children
-            $tags[] = 'parent-' . $signal->locationId;
+            $tags[] = $this->tagProvider->getTagForParentId($signal->locationId);
             // reverse location relations
-            $tags[] = 'relation-location-' . $signal->locationId;
+            $tags[] = $this->tagProvider->getTagForRelationLocationId($signal->locationId);
         }
 
         if (isset($signal->parentLocationId)) {
             // direct parent
-            $tags[] = 'location-' . $signal->parentLocationId;
+            $tags[] = $this->tagProvider->getTagForLocationId($signal->parentLocationId);
             // direct siblings
-            $tags[] = 'parent-' . $signal->parentLocationId;
+            $tags[] = $this->tagProvider->getTagForParentId($signal->parentLocationId);
         }
 
         return $tags;

--- a/src/SignalSlot/AbstractSlot.php
+++ b/src/SignalSlot/AbstractSlot.php
@@ -11,6 +11,7 @@ namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 
 /**
  * A abstract slot covering common functions needed for tag based http cahe slots.
@@ -23,11 +24,18 @@ abstract class AbstractSlot extends Slot
     protected $purgeClient;
 
     /**
-     * @param \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface $purgeClient
+     * @var \EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface
      */
-    public function __construct(PurgeClientInterface $purgeClient)
+    protected $tagProvider;
+
+    /**
+     * @param \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface $purgeClient
+     * @param \EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface $tagProvider
+     */
+    public function __construct(PurgeClientInterface $purgeClient, TagProviderInterface $tagProvider)
     {
         $this->purgeClient = $purgeClient;
+        $this->tagProvider = $tagProvider;
     }
 
     final public function receive(Signal $signal)
@@ -51,7 +59,7 @@ abstract class AbstractSlot extends Slot
     abstract protected function supports(Signal $signal);
 
     /**
-     * Return list of tags to be clered.
+     * Return list of tags to be cleared.
      *
      * @param \eZ\Publish\Core\SignalSlot\Signal $signal
      *

--- a/src/SignalSlot/AssignUserToUserGroupSlot.php
+++ b/src/SignalSlot/AssignUserToUserGroupSlot.php
@@ -17,10 +17,15 @@ class AssignUserToUserGroupSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId, 'ez-user-context-hash'];
+        return [
+            $this->tagProvider->getTagForContentId($signal->userId),
+            $this->tagProvider->getTagForContentId($signal->userGroupId),
+            $this->tagProvider->getTagForUserContextHash(),
+        ];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/ContentTypeService/AssignContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/AssignContentTypeGroupSlot.php
@@ -21,9 +21,10 @@ class AssignContentTypeGroupSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AssignContentTypeGroupSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return [$this->tagProvider->getTagForTypeGroupId($signal->contentTypeGroupId)];
     }
 }

--- a/src/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlot.php
@@ -21,9 +21,10 @@ class DeleteContentTypeGroupSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeGroupSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return [$this->tagProvider->getTagForTypeGroupId($signal->contentTypeGroupId)];
     }
 }

--- a/src/SignalSlot/ContentTypeService/DeleteContentTypeSlot.php
+++ b/src/SignalSlot/ContentTypeService/DeleteContentTypeSlot.php
@@ -23,9 +23,13 @@ class DeleteContentTypeSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-type-' . $signal->contentTypeId, 'type-' . $signal->contentTypeId];
+        return [
+            $this->tagProvider->getTagForContentTypeId($signal->contentTypeId),
+            $this->tagProvider->getTagForTypeId($signal->contentTypeId),
+        ];
     }
 }

--- a/src/SignalSlot/ContentTypeService/PublishContentTypeSlot.php
+++ b/src/SignalSlot/ContentTypeService/PublishContentTypeSlot.php
@@ -23,9 +23,13 @@ class PublishContentTypeSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\PublishContentTypeDraftSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-type-' . $signal->contentTypeDraftId, 'type-' . $signal->contentTypeDraftId];
+        return [
+            $this->tagProvider->getTagForContentTypeId($signal->contentTypeDraftId),
+            $this->tagProvider->getTagForTypeId($signal->contentTypeDraftId),
+        ];
     }
 }

--- a/src/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlot.php
@@ -21,9 +21,10 @@ class UnassignContentTypeGroupSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UnassignContentTypeGroupSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return [$this->tagProvider->getTagForTypeGroupId($signal->contentTypeGroupId)];
     }
 }

--- a/src/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlot.php
@@ -21,9 +21,10 @@ class UpdateContentTypeGroupSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeGroupSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return [$this->tagProvider->getTagForTypeGroupId($signal->contentTypeGroupId)];
     }
 }

--- a/src/SignalSlot/CopyContentSlot.php
+++ b/src/SignalSlot/CopyContentSlot.php
@@ -17,10 +17,15 @@ class CopyContentSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-' . $signal->dstContentId, 'location-' . $signal->dstParentLocationId, 'path-' . $signal->dstParentLocationId];
+        return [
+            $this->tagProvider->getTagForContentId($signal->dstContentId),
+            $this->tagProvider->getTagForLocationId($signal->dstParentLocationId),
+            $this->tagProvider->getTagForPathId($signal->dstParentLocationId),
+        ];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/CopySubtreeSlot.php
+++ b/src/SignalSlot/CopySubtreeSlot.php
@@ -20,9 +20,9 @@ class CopySubtreeSlot extends AbstractContentSlot
         /** @var \eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal $signal */
         return [
             // parent of the new copied tree
-            'location-' . $signal->targetParentLocationId,
+            $this->tagProvider->getTagForLocationId($signal->targetParentLocationId),
             // siblings of the new copied tree
-            'parent-' . $signal->targetParentLocationId,
+            $this->tagProvider->getTagForParentId($signal->targetParentLocationId),
         ];
     }
 

--- a/src/SignalSlot/CreateContentDraftSlot.php
+++ b/src/SignalSlot/CreateContentDraftSlot.php
@@ -20,9 +20,10 @@ class CreateContentDraftSlot extends AbstractSlot
 
     /**
      * @param Signal\ContentService\CreateContentDraftSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-versions-' . $signal->contentId];
+        return [$this->tagProvider->getTagForContentVersions($signal->contentId)];
     }
 }

--- a/src/SignalSlot/DeleteContentSlot.php
+++ b/src/SignalSlot/DeleteContentSlot.php
@@ -17,15 +17,16 @@ class DeleteContentSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal $signal
+     * @return array
      *
-     * @todo Missing parent, however it would be clener if kernel emmited cascading Delete Location signals on affected
+     * @todo Missing parent, however it would be cleaner if kernel emitted cascading Delete Location signals on affected
      *       locations instead.
      */
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
         foreach ($signal->affectedLocationIds as $locationId) {
-            $tags[] = 'path-' . $locationId;
+            $tags[] = $this->tagProvider->getTagForPathId($locationId);
         }
 
         return $tags;

--- a/src/SignalSlot/DeleteLocationSlot.php
+++ b/src/SignalSlot/DeleteLocationSlot.php
@@ -17,11 +17,12 @@ class DeleteLocationSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'path-' . $signal->locationId;
+        $tags[] = $this->tagProvider->getTagForPathId($signal->locationId);
 
         return $tags;
     }

--- a/src/SignalSlot/DeleteVersionSlot.php
+++ b/src/SignalSlot/DeleteVersionSlot.php
@@ -20,9 +20,10 @@ class DeleteVersionSlot extends AbstractSlot
 
     /**
      * @param Signal\ContentService\DeleteVersionSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-versions-' . $signal->contentId];
+        return [$this->tagProvider->getTagForContentVersions($signal->contentId)];
     }
 }

--- a/src/SignalSlot/HideLocationSlot.php
+++ b/src/SignalSlot/HideLocationSlot.php
@@ -17,11 +17,12 @@ class HideLocationSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'path-' . $signal->locationId;
+        $tags[] = $this->tagProvider->getTagForPathId($signal->locationId);
 
         return $tags;
     }

--- a/src/SignalSlot/MoveSubtreeSlot.php
+++ b/src/SignalSlot/MoveSubtreeSlot.php
@@ -17,20 +17,21 @@ class MoveSubtreeSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
         return [
             // The tree being moved
-            'path-' . $signal->locationId,
+            $this->tagProvider->getTagForPathId($signal->locationId),
             // old parent
-            'location-' . $signal->oldParentLocationId,
+            $this->tagProvider->getTagForLocationId($signal->oldParentLocationId),
             // old siblings
-            'parent-' . $signal->oldParentLocationId,
+            $this->tagProvider->getTagForParentId($signal->oldParentLocationId),
             // new parent
-            'location-' . $signal->newParentLocationId,
+            $this->tagProvider->getTagForLocationId($signal->newParentLocationId),
             // new siblings
-            'parent-' . $signal->newParentLocationId,
+            $this->tagProvider->getTagForParentId($signal->newParentLocationId),
         ];
     }
 

--- a/src/SignalSlot/RecoverSlot.php
+++ b/src/SignalSlot/RecoverSlot.php
@@ -21,8 +21,8 @@ class RecoverSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'location-' . $signal->newParentLocationId;
-        $tags[] = 'parent-' . $signal->newParentLocationId;
+        $tags[] = $this->tagProvider->getTagForLocationId($signal->newParentLocationId);
+        $tags[] = $this->tagProvider->getTagForParentId($signal->newParentLocationId);
 
         return $tags;
     }

--- a/src/SignalSlot/RoleService/AbstractPermissionSlot.php
+++ b/src/SignalSlot/RoleService/AbstractPermissionSlot.php
@@ -20,6 +20,6 @@ abstract class AbstractPermissionSlot extends AbstractSlot
     {
         // On permission changes we simply clear user hash cache so next requests will vary on updated hash if a given
         // user was afected. This avoids us having to clear all cache as most or some users might still have same cache.
-        return ['ez-user-context-hash'];
+        return [$this->tagProvider->getTagForUserContextHash()];
     }
 }

--- a/src/SignalSlot/SectionService/DeleteSectionSlot.php
+++ b/src/SignalSlot/SectionService/DeleteSectionSlot.php
@@ -23,9 +23,10 @@ class DeleteSectionSlot extends AbstractSlot
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\SectionService\DeleteSectionSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['section-' . $signal->sectionId];
+        return [$this->tagProvider->getTagForSectionId($signal->sectionId)];
     }
 }

--- a/src/SignalSlot/SectionService/UpdateSectionSlot.php
+++ b/src/SignalSlot/SectionService/UpdateSectionSlot.php
@@ -23,9 +23,10 @@ class UpdateSectionSlot extends AbstractSlot
 
     /**
      * @param Signal\SectionService\UpdateSectionSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['section-' . $signal->sectionId];
+        return [$this->tagProvider->getTagForSectionId($signal->sectionId)];
     }
 }

--- a/src/SignalSlot/SwapLocationSlot.php
+++ b/src/SignalSlot/SwapLocationSlot.php
@@ -17,18 +17,19 @@ class SwapLocationSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
         return [
-            'content-' . $signal->content1Id,
-            'path-' . $signal->location1Id,
-            'location-' . $signal->parentLocation1Id,
-            'parent-' . $signal->parentLocation1Id,
-            'content-' . $signal->content2Id,
-            'path-' . $signal->location2Id,
-            'location-' . $signal->parentLocation2Id,
-            'parent-' . $signal->parentLocation2Id,
+            $this->tagProvider->getTagForContentId($signal->content1Id),
+            $this->tagProvider->getTagForPathId($signal->location1Id),
+            $this->tagProvider->getTagForLocationId($signal->parentLocation1Id),
+            $this->tagProvider->getTagForParentId($signal->parentLocation1Id),
+            $this->tagProvider->getTagForContentId($signal->content2Id),
+            $this->tagProvider->getTagForPathId($signal->location2Id),
+            $this->tagProvider->getTagForLocationId($signal->parentLocation2Id),
+            $this->tagProvider->getTagForParentId($signal->parentLocation2Id),
         ];
     }
 

--- a/src/SignalSlot/UnassignUserFromUserGroupSlot.php
+++ b/src/SignalSlot/UnassignUserFromUserGroupSlot.php
@@ -17,10 +17,15 @@ class UnassignUserFromUserGroupSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId, 'ez-user-context-hash'];
+        return [
+            $this->tagProvider->getTagForContentId($signal->userId),
+            $this->tagProvider->getTagForContentId($signal->userGroupId),
+            $this->tagProvider->getTagForUserContextHash(),
+        ];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/UnhideLocationSlot.php
+++ b/src/SignalSlot/UnhideLocationSlot.php
@@ -17,11 +17,12 @@ class UnhideLocationSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'path-' . $signal->locationId;
+        $tags[] = $this->tagProvider->getTagForPathId($signal->locationId);
 
         return $tags;
     }

--- a/src/SignalSlot/UpdateContentSlot.php
+++ b/src/SignalSlot/UpdateContentSlot.php
@@ -20,9 +20,12 @@ class UpdateContentSlot extends AbstractSlot
 
     /**
      * @param Signal\ContentService\UpdateContentSignal $signal
+     * @return array
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-versions-' . $signal->contentId];
+        return [
+            $this->tagProvider->getTagForContentVersions($signal->contentId),
+        ];
     }
 }

--- a/src/SignalSlot/UpdateUrlSlot.php
+++ b/src/SignalSlot/UpdateUrlSlot.php
@@ -11,6 +11,7 @@ namespace EzSystems\PlatformHttpCacheBundle\SignalSlot;
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\SPI\Persistence\URL\Handler as UrlHandler;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 
 /**
  * A slot handling UpdateUrlSignal.
@@ -24,23 +25,25 @@ class UpdateUrlSlot extends AbstractContentSlot
      * UpdateUrlSlot constructor.
      *
      * @param PurgeClientInterface $purgeClient
+     * @param TagProviderInterface $tagProvider
      * @param UrlHandler $urlHandler
      */
-    public function __construct(PurgeClientInterface $purgeClient, UrlHandler $urlHandler)
+    public function __construct(PurgeClientInterface $purgeClient, TagProviderInterface $tagProvider, UrlHandler $urlHandler)
     {
-        parent::__construct($purgeClient);
+        parent::__construct($purgeClient, $tagProvider);
 
         $this->urlHandler = $urlHandler;
     }
 
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\URLService\UpdateUrlSignal $signal
+     * @return array
      */
     public function generateTags(Signal $signal)
     {
         if ($signal->urlChanged) {
             return array_map(function ($contentId) {
-                return 'content-' . $contentId;
+                return $this->tagProvider->getTagForContentId($contentId);
             }, $this->urlHandler->findUsages($signal->urlId));
         }
 

--- a/src/TagProvider/ShortToLongTagConverter.php
+++ b/src/TagProvider/ShortToLongTagConverter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\TagProvider;
+
+final class ShortToLongTagConverter
+{
+    const SHORT_MAPPING = 'short';
+    const LONG_MAPPING = 'long';
+
+    /**
+     * @var array
+     */
+    private $mapping;
+
+    public function __construct(array $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    public function convert($tag)
+    {
+        $tagElements = \explode(TagProviderInterface::DELIMITER, $tag);
+
+        // Given tag is already in long format, skipping.
+        if (isset($tagElements[0]) && strlen($tagElements[0]) > 3) {
+            return $tag;
+        }
+
+        $tagValue = \array_pop($tagElements);
+        $tagKey = \implode(TagProviderInterface::DELIMITER, $tagElements);
+
+        foreach ($this->mapping[self::SHORT_MAPPING] as $key => $value) {
+            if ($tagKey === $value) {
+                return $this->mapping[self::LONG_MAPPING][$key] . TagProviderInterface::DELIMITER . $tagValue;
+            }
+        }
+
+        @trigger_error(
+            "Could not convert {$tag} from short to long format",
+            E_USER_WARNING
+        );
+    }
+}

--- a/src/TagProvider/TagProvider.php
+++ b/src/TagProvider/TagProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace EzSystems\PlatformHttpCacheBundle\TagProvider;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+final class TagProvider implements TagProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $tagsMap;
+
+    /**
+     * @var string
+     */
+    private $userContextHashTag;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    public function __construct(ConfigResolverInterface $configResolver, array $tagsMap, $userContextHashTag)
+    {
+        $this->userContextHashTag = $userContextHashTag;
+        $this->tagsMap = $tagsMap;
+        $this->type = $configResolver->getParameter('http_cache.tag_format');
+    }
+
+    public function getTagForLocationId($locationId)
+    {
+        return $this->tagsMap[$this->type][self::LOCATION_KEY] . self::DELIMITER . (string)$locationId;
+    }
+
+    public function getTagForContentId($contentId)
+    {
+        return $this->tagsMap[$this->type][self::CONTENT_KEY] . self::DELIMITER . (string)$contentId;
+    }
+
+    public function getTagForContentTypeId($contentTypeId)
+    {
+        return $this->tagsMap[$this->type][self::CONTENT_TYPE_KEY] . self::DELIMITER . (string)$contentTypeId;
+    }
+
+    public function getTagForContentVersions($contentInfoId)
+    {
+        return $this->tagsMap[$this->type][self::CONTENT_VERSIONS_KEY] . self::DELIMITER . (string)$contentInfoId;
+    }
+
+    public function getTagForParentId($parentId)
+    {
+        return $this->tagsMap[$this->type][self::PARENT_KEY] . self::DELIMITER . (string)$parentId;
+    }
+
+    public function getTagForRelationId($contentId)
+    {
+        return $this->tagsMap[$this->type][self::RELATION_KEY] . self::DELIMITER . (string)$contentId;
+    }
+
+    public function getTagForRelationLocationId($reverseRelationId)
+    {
+        return $this->tagsMap[$this->type][self::RELATION_LOCATION_KEY] . self::DELIMITER . (string)$reverseRelationId;
+    }
+
+    public function getTagForPathId($pathId)
+    {
+        return $this->tagsMap[$this->type][self::PATH_KEY] . self::DELIMITER . (string)$pathId;
+    }
+
+    public function getTagForSectionId($sectionId)
+    {
+        return $this->tagsMap[$this->type][self::SECTION_KEY] . self::DELIMITER . (string)$sectionId;
+    }
+
+    public function getTagForTypeId($typeId)
+    {
+        return $this->tagsMap[$this->type][self::TYPE_KEY] . self::DELIMITER . (string)$typeId;
+    }
+
+    public function getTagForTypeGroupId($typeGroupId)
+    {
+        return $this->tagsMap[$this->type][self::TYPE_GROUP_KEY] . self::DELIMITER . (string)$typeGroupId;
+    }
+
+    public function getTagForAll()
+    {
+        return $this->tagsMap[$this->type][self::ALL_KEY];
+    }
+
+    public function getTagForUserContextHash()
+    {
+        return $this->userContextHashTag;
+    }
+}

--- a/src/TagProvider/TagProvider.php
+++ b/src/TagProvider/TagProvider.php
@@ -4,7 +4,7 @@ namespace EzSystems\PlatformHttpCacheBundle\TagProvider;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
-final class TagProvider implements TagProviderInterface
+class TagProvider implements TagProviderInterface
 {
     /**
      * @var array

--- a/src/TagProvider/TagProviderInterface.php
+++ b/src/TagProvider/TagProviderInterface.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * File containing the TagProviderInterface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\TagProvider;
+
+interface TagProviderInterface
+{
+    const LOCATION_KEY = 'location';
+    const CONTENT_KEY = 'content';
+    const CONTENT_TYPE_KEY = 'contentType';
+    const CONTENT_VERSIONS_KEY = 'contentVersions';
+    const PARENT_KEY = 'parent';
+    const RELATION_KEY = 'relation';
+    const RELATION_LOCATION_KEY = 'relationLocation';
+    const PATH_KEY = 'path';
+    const TYPE_KEY = 'type';
+    const TYPE_GROUP_KEY = 'typeGroup';
+    const SECTION_KEY = 'section';
+    const ALL_KEY = 'all';
+    const DELIMITER = '-';
+
+    /**
+     * @param int $locationId
+     * @return string
+     */
+    public function getTagForLocationId($locationId);
+
+    /**
+     * @param int $contentId
+     * @return string
+     */
+    public function getTagForContentId($contentId);
+
+    /**
+     * @param int $contentTypeId
+     * @return string
+     */
+    public function getTagForContentTypeId($contentTypeId);
+
+    /**
+     * @param int $contentInfoId
+     * @return string
+     */
+    public function getTagForContentVersions($contentInfoId);
+
+    /**
+     * @param int $parentId
+     * @return string
+     */
+    public function getTagForParentId($parentId);
+
+    /**
+     * @param int $contentId
+     * @return string
+     */
+    public function getTagForRelationId($contentId);
+
+    /**
+     * @param int $reverseRelationId
+     * @return string
+     */
+    public function getTagForRelationLocationId($reverseRelationId);
+
+    /**
+     * @param int $pathId
+     * @return string
+     */
+    public function getTagForPathId($pathId);
+
+    /**
+     * @param int $sectionId
+     * @return string
+     */
+    public function getTagForSectionId($sectionId);
+
+    /**
+     * @param int $typeId
+     * @return string
+     */
+    public function getTagForTypeId($typeId);
+
+    /**
+     * @param int $typeGroupId
+     * @return string
+     */
+    public function getTagForTypeGroupId($typeGroupId);
+
+    /**
+     * @return string
+     */
+    public function getTagForAll();
+
+    /**
+     * @return string
+     */
+    public function getTagForUserContextHash();
+}

--- a/tests/Proxy/TagAwareStoreTest.php
+++ b/tests/Proxy/TagAwareStoreTest.php
@@ -9,6 +9,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\Tests\Proxy;
 
 use EzSystems\PlatformHttpCacheBundle\Proxy\TagAwareStore;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Filesystem\Filesystem;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +24,8 @@ class TagAwareStoreTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->store = new TagAwareStore(__DIR__);
+        $this->tagProviderMock = $this->createMock(TagProviderInterface::class);
+        $this->store = new TagAwareStore(__DIR__, $this->tagProviderMock);
     }
 
     protected function tearDown()

--- a/tests/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/PurgeClient/LocalPurgeClientTest.php
@@ -22,6 +22,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests;
 
 use EzSystems\PlatformHttpCacheBundle\RequestAwarePurger;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -39,7 +40,27 @@ class LocalPurgeClientTest extends TestCase
             ->method('purgeByRequest')
             ->with($this->equalTo($expectedBanRequest));
 
-        $purgeClient = new LocalPurgeClient($cacheStore);
+        $tagProviderMock = $this->createMock(TagProviderInterface::class);
+
+        $tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForLocationId')
+            ->with(123)
+            ->willReturn('location-123');
+
+        $tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForLocationId')
+            ->with(456)
+            ->willReturn('location-456');
+
+        $tagProviderMock
+            ->expects($this->at(2))
+            ->method('getTagForLocationId')
+            ->with(789)
+            ->willReturn('location-789');
+
+        $purgeClient = new LocalPurgeClient($cacheStore, $tagProviderMock);
         $purgeClient->purge($locationIds);
     }
 }

--- a/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -11,6 +11,7 @@ namespace EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\RepositoryPrefixDecorator;
 use EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use PHPUnit\Framework\TestCase;
 
 class RepositoryPrefixDecoratorTest extends TestCase
@@ -30,18 +31,24 @@ class RepositoryPrefixDecoratorTest extends TestCase
      */
     private $prefixDecorator;
 
+    /**
+     * @var TagProviderInterface
+     */
+    private $tagProviderMock;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->purgeClientMock = $this->createMock(PurgeClientInterface::class);
         $this->tagPrefixMock = $this->createMock(RepositoryTagPrefix::class);
-        $this->prefixDecorator = new RepositoryPrefixDecorator($this->purgeClientMock, $this->tagPrefixMock);
+        $this->tagProviderMock = $this->createMock(TagProviderInterface::class);
+        $this->prefixDecorator = new RepositoryPrefixDecorator($this->purgeClientMock, $this->tagPrefixMock, $this->tagProviderMock);
     }
 
     protected function tearDown()
     {
-        unset($this->purgeClientMock, $this->tagPrefixMock, $this->prefixDecorator);
+        unset($this->purgeClientMock, $this->tagPrefixMock, $this->prefixDecorator, $this->tagProviderMock);
 
         parent::tearDown();
     }
@@ -58,6 +65,12 @@ class RepositoryPrefixDecoratorTest extends TestCase
             ->method('getRepositoryPrefix')
             ->willReturn('');
 
+        $this->tagProviderMock
+            ->expects($this->once())
+            ->method('getTagForLocationId')
+            ->with(123)
+            ->willReturn('location-123');
+
         $this->prefixDecorator->purge([123, 'content-44', 'ez-all']);
     }
 
@@ -72,6 +85,12 @@ class RepositoryPrefixDecoratorTest extends TestCase
             ->expects($this->once())
             ->method('getRepositoryPrefix')
             ->willReturn('intranet_');
+
+        $this->tagProviderMock
+            ->expects($this->once())
+            ->method('getTagForLocationId')
+            ->with(123)
+            ->willReturn('location-123');
 
         $this->prefixDecorator->purge([123, 'content-44', 'ez-all']);
     }

--- a/tests/SignalSlot/AbstractContentSlotTest.php
+++ b/tests/SignalSlot/AbstractContentSlotTest.php
@@ -20,23 +20,64 @@ abstract class AbstractContentSlotTest extends AbstractSlotTest
     public function generateTags()
     {
         $tags = [];
+
         if ($this->contentId) {
-            $tags = ['content-' . $this->contentId, 'relation-' . $this->contentId];
+            $this->tagProviderMock
+                ->method('getTagForContentId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'content-' . $arg;
+                });
+            $tags[] = 'content-' . $this->contentId;
+
+            $this->tagProviderMock
+                ->method('getTagForRelationId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'relation-' . $arg;
+                });
+            $tags[] = 'relation-' . $this->contentId;
         }
 
         if ($this->locationId) {
             // self(s)
+            $this->tagProviderMock
+                ->method('getTagForLocationId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'location-' . $arg;
+                });
             $tags[] = 'location-' . $this->locationId;
+
             // children
+            $this->tagProviderMock
+                ->method('getTagForParentId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'parent-' . $arg;
+                });
             $tags[] = 'parent-' . $this->locationId;
+
             // reverse location relations
+            $this->tagProviderMock
+                ->method('getTagForRelationLocationId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'relation-location-' . $arg;
+                });
             $tags[] = 'relation-location-' . $this->locationId;
         }
 
         if ($this->parentLocationId) {
             // parent(s)
+            $this->tagProviderMock
+                ->method('getTagForLocationId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'location-' . $arg;
+                });
             $tags[] = 'location-' . $this->parentLocationId;
+
             // siblings
+            $this->tagProviderMock
+                ->method('getTagForParentId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'parent-' . $arg;
+                });
             $tags[] = 'parent-' . $this->parentLocationId;
         }
 

--- a/tests/SignalSlot/AbstractPublishSlotTest.php
+++ b/tests/SignalSlot/AbstractPublishSlotTest.php
@@ -26,7 +26,7 @@ abstract class AbstractPublishSlotTest extends AbstractContentSlotTest
             $this->spiLocationHandlerMock = $this->createMock(Handler::class);
         }
 
-        return new $class($this->purgeClientMock, $this->spiLocationHandlerMock);
+        return new $class($this->purgeClientMock, $this->tagProviderMock, $this->spiLocationHandlerMock);
     }
 
     /**

--- a/tests/SignalSlot/AbstractSlotTest.php
+++ b/tests/SignalSlot/AbstractSlotTest.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface;
+use EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractSlotTest extends TestCase
@@ -20,12 +21,16 @@ abstract class AbstractSlotTest extends TestCase
     /** @var \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $purgeClientMock;
 
+    /** @var \EzSystems\PlatformHttpCacheBundle\TagProvider\TagProviderInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $tagProviderMock;
+
     /** @var \eZ\Publish\Core\SignalSlot\Signal */
     private $signal;
 
     public function setUp()
     {
         $this->purgeClientMock = $this->createMock(PurgeClientInterface::class);
+        $this->tagProviderMock = $this->createMock(TagProviderInterface::class);
         $this->slot = $this->createSlot();
         $this->signal = $this->createSignal();
     }
@@ -34,7 +39,7 @@ abstract class AbstractSlotTest extends TestCase
     {
         $class = $this->getSlotClass();
 
-        return new $class($this->purgeClientMock);
+        return new $class($this->purgeClientMock, $this->tagProviderMock);
     }
 
     /**

--- a/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
+++ b/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
@@ -20,6 +20,23 @@ class AssignUserToUserGroupSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForContentId')
+            ->with($this->contentId)
+            ->willReturn("content-{$this->contentId}");
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForContentId')
+            ->with(99)
+            ->willReturn('content-99');
+
+        $this->tagProviderMock
+            ->expects($this->at(2))
+            ->method('getTagForUserContextHash')
+            ->willReturn('ez-user-context-hash');
+
         return ['content-' . $this->contentId, 'content-99', 'ez-user-context-hash'];
     }
 

--- a/tests/SignalSlot/ContentService/CreateContentDraftSlotTest.php
+++ b/tests/SignalSlot/ContentService/CreateContentDraftSlotTest.php
@@ -19,7 +19,13 @@ class CreateContentDraftSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-versions-55'];
+        $tag = 'content-versions-55';
+        $this->tagProviderMock
+            ->method('getTagForContentVersions')
+            ->with(55)
+            ->willReturn($tag);
+
+        return [$tag];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentService/DeleteVersionSlotTest.php
+++ b/tests/SignalSlot/ContentService/DeleteVersionSlotTest.php
@@ -19,7 +19,13 @@ class DeleteVersionSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-versions-55'];
+        $tag = 'content-versions-55';
+        $this->tagProviderMock
+            ->method('getTagForContentVersions')
+            ->with(55)
+            ->willReturn($tag);
+
+        return [$tag];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentService/UpdateContentSlotTest.php
+++ b/tests/SignalSlot/ContentService/UpdateContentSlotTest.php
@@ -19,7 +19,13 @@ class UpdateContentSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-versions-55'];
+        $tag = 'content-versions-55';
+        $this->tagProviderMock
+            ->method('getTagForContentVersions')
+            ->with(55)
+            ->willReturn($tag);
+
+        return [$tag];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentTypeService/AssignContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/AssignContentTypeGroupSlotTest.php
@@ -21,7 +21,14 @@ class AssignContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['type-group-4'];
+        $groupId = 4;
+        $tag = 'type-group-' . $groupId;
+        $this->tagProviderMock
+            ->method('getTagForTypeGroupId')
+            ->with($groupId)
+            ->willReturn($tag);
+
+        return [$tag];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlotTest.php
@@ -21,7 +21,14 @@ class DeleteContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['type-group-4'];
+        $groupId = 4;
+        $tag = 'type-group-' . $groupId;
+        $this->tagProviderMock
+            ->method('getTagForTypeGroupId')
+            ->with($groupId)
+            ->willReturn($tag);
+
+        return [$tag];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/DeleteContentTypeSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/DeleteContentTypeSlotTest.php
@@ -21,6 +21,18 @@ class DeleteContentTypeSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForContentTypeId')
+            ->with(4)
+            ->willReturn('content-type-4');
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForTypeId')
+            ->with(4)
+            ->willReturn('type-4');
+
         return ['content-type-4', 'type-4'];
     }
 

--- a/tests/SignalSlot/ContentTypeService/PublishContentTypeSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/PublishContentTypeSlotTest.php
@@ -21,6 +21,18 @@ class PublishContentTypeSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForContentTypeId')
+            ->with(4)
+            ->willReturn('content-type-4');
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForTypeId')
+            ->with(4)
+            ->willReturn('type-4');
+
         return ['content-type-4', 'type-4'];
     }
 

--- a/tests/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlotTest.php
@@ -21,6 +21,12 @@ class UnassignContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForTypeGroupId')
+            ->with(4)
+            ->willReturn('type-group-4');
+
         return ['type-group-4'];
     }
 

--- a/tests/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlotTest.php
@@ -21,6 +21,12 @@ class UpdateContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForTypeGroupId')
+            ->with(4)
+            ->willReturn('type-group-4');
+
         return ['type-group-4'];
     }
 

--- a/tests/SignalSlot/CopyContentSlotTest.php
+++ b/tests/SignalSlot/CopyContentSlotTest.php
@@ -9,6 +9,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal;
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\CopyContentSlot;
 
 class CopyContentSlotTest extends AbstractContentSlotTest
 {
@@ -21,16 +22,34 @@ class CopyContentSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForContentId')
+            ->with($this->contentId)
+            ->willReturn("content-{$this->contentId}");
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForLocationId')
+            ->with($this->parentLocationId)
+            ->willReturn("location-{$this->parentLocationId}");
+
+        $this->tagProviderMock
+            ->expects($this->at(2))
+            ->method('getTagForPathId')
+            ->with($this->parentLocationId)
+            ->willReturn("path-{$this->parentLocationId}");
+
         return ['content-' . $this->contentId, 'location-' . $this->parentLocationId, 'path-' . $this->parentLocationId];
     }
 
     public function getSlotClass()
     {
-        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\CopyContentSlot';
+        return CopyContentSlot::class;
     }
 
     public function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal'];
+        return [CopyContentSignal::class];
     }
 }

--- a/tests/SignalSlot/CopySubtreeSlotTest.php
+++ b/tests/SignalSlot/CopySubtreeSlotTest.php
@@ -28,6 +28,18 @@ class CopySubtreeSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForLocationId')
+            ->with($this->targetParentLocationId)
+            ->willReturn("location-{$this->targetParentLocationId}");
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForParentId')
+            ->with($this->targetParentLocationId)
+            ->willReturn("parent-{$this->targetParentLocationId}");
+
         return [
             'location-' . $this->targetParentLocationId,
             'parent-' . $this->targetParentLocationId,

--- a/tests/SignalSlot/DeleteContentSlotTest.php
+++ b/tests/SignalSlot/DeleteContentSlotTest.php
@@ -9,17 +9,29 @@
 namespace EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
+use EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteContentSlot;
 
 class DeleteContentSlotTest extends AbstractContentSlotTest
 {
+    const AFFECTED_LOCATION_IDS = [45, 55];
+
     public function createSignal()
     {
-        return new DeleteContentSignal(['contentId' => $this->contentId, 'affectedLocationIds' => [45, 55]]);
+        return new DeleteContentSignal(['contentId' => $this->contentId, 'affectedLocationIds' => self::AFFECTED_LOCATION_IDS]);
     }
 
     public function generateTags()
     {
         $tags = parent::generateTags();
+
+        foreach (self::AFFECTED_LOCATION_IDS as $key => $affectedLocationId) {
+            $this->tagProviderMock
+                ->method('getTagForPathId')
+                ->willReturnCallback(static function ($arg) {
+                    return 'path-' . $arg;
+                });
+        }
+
         $tags[] = 'path-45';
         $tags[] = 'path-55';
 
@@ -28,11 +40,11 @@ class DeleteContentSlotTest extends AbstractContentSlotTest
 
     public function getSlotClass()
     {
-        return 'EzSystems\PlatformHttpCacheBundle\SignalSlot\DeleteContentSlot';
+        return DeleteContentSlot::class;
     }
 
     public function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal'];
+        return [DeleteContentSignal::class];
     }
 }

--- a/tests/SignalSlot/DeleteLocationSlotTest.php
+++ b/tests/SignalSlot/DeleteLocationSlotTest.php
@@ -29,7 +29,12 @@ class DeleteLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
-        $tags[] = 'path-' . $this->locationId;
+        $pathTag = 'path-' . $this->locationId;
+        $this->tagProviderMock
+            ->method('getTagForPathId')
+            ->with($this->locationId)
+            ->willReturn($pathTag);
+        $tags[] = $pathTag;
 
         return $tags;
     }

--- a/tests/SignalSlot/HideLocationSlotTest.php
+++ b/tests/SignalSlot/HideLocationSlotTest.php
@@ -27,6 +27,11 @@ class HideLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
+
+        $this->tagProviderMock
+            ->method('getTagForPathId')
+            ->willReturn('path-' . $this->locationId);
+
         $tags[] = 'path-' . $this->locationId;
 
         return $tags;

--- a/tests/SignalSlot/MoveSubtreeSlotTest.php
+++ b/tests/SignalSlot/MoveSubtreeSlotTest.php
@@ -29,6 +29,31 @@ class MoveSubtreeSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForPathId')
+            ->willReturn('path-' . $this->locationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForLocationId')
+            ->willReturn('location-' . $this->oldParentLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(2))
+            ->method('getTagForParentId')
+            ->willReturn('parent-' . $this->oldParentLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(3))
+            ->method('getTagForLocationId')
+            ->willReturn('location-' . $this->parentLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(4))
+            ->method('getTagForParentId')
+            ->willReturn('parent-' . $this->parentLocationId);
+
         return ['path-' . $this->locationId, 'location-' . $this->oldParentLocationId, 'parent-' . $this->oldParentLocationId, 'location-' . $this->parentLocationId, 'parent-' . $this->parentLocationId];
     }
 

--- a/tests/SignalSlot/RecoverSlotTest.php
+++ b/tests/SignalSlot/RecoverSlotTest.php
@@ -29,10 +29,10 @@ class RecoverSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         return [
-            'content-' . $this->contentId,
-            'relation-' . $this->contentId,
-            'location-' . $this->parentLocationId,
-            'parent-' . $this->parentLocationId,
+            $this->tagProviderMock->getTagForContentId($this->contentId),
+            $this->tagProviderMock->getTagForRelationId($this->contentId),
+            $this->tagProviderMock->getTagForLocationId($this->parentLocationId),
+            $this->tagProviderMock->getTagForParentId($this->parentLocationId),
         ];
     }
 

--- a/tests/SignalSlot/RoleService/AbstractPermissionSlotTest.php
+++ b/tests/SignalSlot/RoleService/AbstractPermissionSlotTest.php
@@ -14,6 +14,10 @@ abstract class AbstractPermissionSlotTest extends AbstractSlotTest
 {
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->method('getTagForUserContextHash')
+            ->willReturn('ez-user-context-hash');
+
         return ['ez-user-context-hash'];
     }
 }

--- a/tests/SignalSlot/SectionService/DeleteSectionSlotTest.php
+++ b/tests/SignalSlot/SectionService/DeleteSectionSlotTest.php
@@ -21,6 +21,10 @@ class DeleteSectionSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->method('getTagForSectionId')
+            ->willReturn('section-2');
+
         return ['section-2'];
     }
 

--- a/tests/SignalSlot/SectionService/UpdateSectionSlotTest.php
+++ b/tests/SignalSlot/SectionService/UpdateSectionSlotTest.php
@@ -21,6 +21,10 @@ class UpdateSectionSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->method('getTagForSectionId')
+            ->willReturn('section-2');
+
         return ['section-2'];
     }
 

--- a/tests/SignalSlot/SwapLocationSlotTest.php
+++ b/tests/SignalSlot/SwapLocationSlotTest.php
@@ -33,6 +33,46 @@ class SwapLocationSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForContentId')
+            ->willReturn('content-' . $this->contentId);
+
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForPathId')
+            ->willReturn('path-' . $this->locationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(2))
+            ->method('getTagForLocationId')
+            ->willReturn('location-' . $this->parentLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(3))
+            ->method('getTagForParentId')
+            ->willReturn('parent-' . $this->parentLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(4))
+            ->method('getTagForContentId')
+            ->willReturn('content-' . $this->swapContentId);
+
+        $this->tagProviderMock
+            ->expects($this->at(5))
+            ->method('getTagForPathId')
+            ->willReturn('path-' . $this->swapLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(6))
+            ->method('getTagForLocationId')
+            ->willReturn('location-' . $this->swapParentLocationId);
+
+        $this->tagProviderMock
+            ->expects($this->at(7))
+            ->method('getTagForParentId')
+            ->willReturn('parent-' . $this->swapParentLocationId);
+
         return [
             'content-' . $this->contentId,
             'path-' . $this->locationId,

--- a/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
+++ b/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
@@ -20,6 +20,18 @@ class UnassignUserFromUserGroupSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
+        $this->tagProviderMock
+            ->expects($this->at(0))
+            ->method('getTagForContentId')
+            ->willReturn('content-' . $this->contentId);
+        $this->tagProviderMock
+            ->expects($this->at(1))
+            ->method('getTagForContentId')
+            ->willReturn('content-99');
+        $this->tagProviderMock
+            ->method('getTagForUserContextHash')
+            ->willReturn('ez-user-context-hash');
+
         return ['content-' . $this->contentId, 'content-99', 'ez-user-context-hash'];
     }
 

--- a/tests/SignalSlot/UnhideLocationSlotTest.php
+++ b/tests/SignalSlot/UnhideLocationSlotTest.php
@@ -27,6 +27,13 @@ class UnhideLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
+
+        $this->tagProviderMock
+            ->expects($this->once())
+            ->method('getTagForPathId')
+            ->with($this->locationId)
+            ->willReturn('path-' . $this->locationId);
+
         $tags[] = 'path-' . $this->locationId;
 
         return $tags;

--- a/tests/SignalSlot/UpdateUrlSlotTest.php
+++ b/tests/SignalSlot/UpdateUrlSlotTest.php
@@ -45,7 +45,7 @@ class UpdateUrlSlotTest extends AbstractSlotTest
                 ->willReturn(self::CONTENT_IDS);
         }
 
-        return new $class($this->purgeClientMock, $this->spiUrlHandlerMock);
+        return new $class($this->purgeClientMock, $this->tagProviderMock, $this->spiUrlHandlerMock);
     }
 
     public function createSignal()
@@ -58,9 +58,17 @@ class UpdateUrlSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return array_map(function ($id) {
-            return 'content-' . $id;
-        }, self::CONTENT_IDS);
+        $tags = [];
+
+        foreach (self::CONTENT_IDS as $key => $contentId) {
+            $this->tagProviderMock
+                ->expects($this->at($key))
+                ->method('getTagForContentId')
+                ->willReturn('content-' . $contentId);
+            $tags[] = 'content-' . $contentId;
+        }
+
+        return $tags;
     }
 
     public function getReceivedSignalClasses()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30562](https://jira.ez.no/browse/EZP-30562)
| **Type**           | Feature
| **Target version** | `0.9` / `master`
| **BC breaks**      | no*
| **Doc needed**     | yes

This PR introduces new `TagProvider` to get rid of hardcoded tags all around this bundle codebase. Moreover, shortening of the tags should help to solve recently reported Apache + PHP-FPM issues.

`ezplatform.http_cache.tag_provider` has been set as lazy, because in v1 there was an issue that `ConfigResolver` couldn't find the `http_cache.tag_format` parameter. 

`*` - _PR contains also `ShortToLongTagConverter` which has been made for BC, in other words, we don't want to force hard HTTP cache clear after the upgrade. It should be removed in the next major version, I think._

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Cover new Twig function `ez_httpcache_tag_*` in https://github.com/ezsystems/ezplatform-http-cache/blob/master/docs/using_tags.md
- [x] Ask for Code Review.