### PR TITLE
EZP-30560: Unable to clear Varnish cache

### DIFF
--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -90,9 +90,8 @@ class VarnishPurgeClient implements PurgeClientInterface
     {
         $server = $this->configResolver->getParameter('http_cache.purge_servers')[0];
         $host = parse_url($server, PHP_URL_HOST);
-        if ($host) {
-            $headers['Host'] = $host;
-        }
+
+        $headers['Host'] = $host ?: $_SERVER['SERVER_NAME'];
 
         return $headers;
     }

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -53,9 +53,9 @@ class VarnishPurgeClient implements PurgeClientInterface
 
             $headers = [
                 'key' => $tag,
-                'Host' => empty($_SERVER['SERVER_NAME']) ? parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST) : $_SERVER['SERVER_NAME'],
             ];
 
+            $headers = $this->addHostHeader($headers);
             $headers = $this->addPurgeAuthHeader($headers);
 
             $this->cacheManager->invalidatePath(
@@ -69,15 +69,32 @@ class VarnishPurgeClient implements PurgeClientInterface
     {
         $headers = [
             'key' => 'ez-all',
-            'Host' => empty($_SERVER['SERVER_NAME']) ? parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST) : $_SERVER['SERVER_NAME'],
         ];
 
+        $headers = $this->addHostHeader($headers);
         $headers = $this->addPurgeAuthHeader($headers);
 
         $this->cacheManager->invalidatePath(
             '/',
             $headers
         );
+    }
+
+    /**
+     * Adds a Host header for Purge.
+     *
+     * @param array $headers
+     * @return array
+     */
+    private function addHostHeader(array $headers)
+    {
+        $server = $this->configResolver->getParameter('http_cache.purge_servers')[0];
+        $host = parse_url($server, PHP_URL_HOST);
+        if ($host) {
+            $headers['Host'] = $host;
+        }
+
+        return $headers;
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30560](https://jira.ez.no/browse/EZP-30560)
| **Type**           | Bug
| **Target version** | latest stable `0.8`
| **BC breaks**      | no
| **Doc needed**     | no

Let's say there is eZ Platform site on Platform.sh. Own domain is used to access the admin. So site has following domains:
- https://project.com for front-end
- https://admin.project.com for admin UI

Front-end (https://project.com) is served by Varnish, but admin is not:
```
// .platform/routes.yaml
https://project.com:
    type: upstream
    upstream: varnish:http
https://admin.project.com:
    type: upstream
    upstream: app:http
```

When you edit/publish some content in admin UI (https://admin.project.com), it is expected that its Varnish cache will be cleared. But actually, the Varnish cache is not cleared.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
