### PR TITLE
EZP-30544: Move cache stuff from Kernel

### DIFF
--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -48,6 +48,11 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('fos_http_cache', $config);
         $container->addResource(new FileResource($configFile));
+
+        // Override Core views
+        $coreExtensionConfigFile = realpath(__DIR__ . '/../Resources/config/prepend/ezpublish.yml');
+        $container->prependExtensionConfig('ezpublish', Yaml::parseFile($coreExtensionConfigFile));
+        $container->addResource(new FileResource($coreExtensionConfigFile));
     }
 
     public function addExtraConfigParser(ParserInterface $configParser)

--- a/src/EventSubscriber/UserContextSiteAccessMatchSubscriber.php
+++ b/src/EventSubscriber/UserContextSiteAccessMatchSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class UserContextSiteAccessMatchSubscriber implements EventSubscriberInterface
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener */
+    protected $innerSubscriber;
+
+    /** @var \Symfony\Component\HttpFoundation\RequestMatcherInterface */
+    private $userContextRequestMatcher;
+
+    public function __construct(
+        SiteAccessMatchListener $innerSubscriber,
+        RequestMatcherInterface $userContextRequestMatcher
+    ) {
+        $this->innerSubscriber = $innerSubscriber;
+        $this->userContextRequestMatcher = $userContextRequestMatcher;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            // Should take place just after FragmentListener (priority 48) in order to get rebuilt request attributes in case of subrequest
+            KernelEvents::REQUEST => ['checkIfRequestForUserContextHash', 45],
+        ];
+    }
+
+    public function checkIfRequestForUserContextHash(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+
+        // Don't try to match when it's request for user hash . SiteAccess is irrelevant in this case.
+        if ($this->userContextRequestMatcher->matches($request) && !$request->attributes->has('_ez_original_request')) {
+            return;
+        }
+
+        $this->innerSubscriber->onKernelRequest($event);
+    }
+}

--- a/src/Resources/config/prepend/ezpublish.yml
+++ b/src/Resources/config/prepend/ezpublish.yml
@@ -1,0 +1,5 @@
+system:
+    default:
+        field_templates:
+            -   template: '@EzSystemsPlatformHttpCache/fields/content_fields.html.twig'
+                priority: 5

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -32,6 +32,14 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSiteAccessMatchSubscriber:
+        decorates: ezpublish.siteaccess_match_listener
+        arguments:
+            - '@EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSiteAccessMatchSubscriber.inner'
+            - '@fos_http_cache.user_context.request_matcher'
+        tags:
+            - { name: kernel.event_subscriber }
+
     # ResponseConfigurator
     ezplatform.view_cache.response_configurator:
         class: EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator

--- a/src/Resources/views/fields/content_fields.html.twig
+++ b/src/Resources/views/fields/content_fields.html.twig
@@ -1,0 +1,47 @@
+{% trans_default_domain "content_fields" %}
+
+{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+
+{% block ezobjectrelationlist_field %}
+    {% spaceless %}
+        {% if not ez_field_is_empty( content, field ) %}
+            <ul {{ block( 'field_attributes' ) }}>
+                {% for contentId in field.value.destinationContentIds if parameters.available[contentId] %}
+                     {{ fos_httpcache_tag('relation-' ~ contentId) }}
+                    <li>
+                        {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}
+
+{% block ezimageasset_field %}
+    {% spaceless %}
+        {% if not ez_field_is_empty(content, field) and parameters.available %}
+            {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
+            <div {{ block('field_attributes') }}>
+                {{ render(controller('ez_content:embedAction', {
+                    contentId: field.value.destinationContentId,
+                    viewType: 'asset_image',
+                    no_layout: true,
+                    params: {
+                        parameters: parameters|default({'alias': 'original'})|merge({'alternativeText': field.value.alternativeText })
+                    }
+                }))}}
+            </div>
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}
+
+{% block ezobjectrelation_field %}
+    {% spaceless %}
+        {% if not ez_field_is_empty( content, field ) and parameters.available %}
+            {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
+            <div {{ block( 'field_attributes' ) }}>
+                {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
+            </div>
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30544](https://jira.ez.no/browse/EZP-30544)
| **Type**           | Improvement
| **Target version** | `master`
| **BC breaks**      | yes/no
| **Doc needed**     | yes/no

Related:
https://github.com/ezsystems/ezplatform-http-cache/pull/89 (as this PR contains also this one.)
https://github.com/ezsystems/ezpublish-kernel/pull/2678/files

Relevant Commits:
https://github.com/ezsystems/ezplatform-http-cache/pull/90/commits/fa6e767deeb762de4992a434ea2d6a2b47de32f5
https://github.com/ezsystems/ezplatform-http-cache/pull/90/commits/7dbf6b97e3670c530a54e3f929aa71044e2fda95

**TODO**:
- [ ] REBASE
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
