### PR TITLE
EZP-30544: Refactored to use FOSHttpCache default ResponseHeader

### DIFF
--- a/src/AppCache.php
+++ b/src/AppCache.php
@@ -11,6 +11,7 @@ use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
+use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,7 +49,7 @@ class AppCache extends HttpCache implements CacheInvalidation
     protected function createStore()
     {
         return new Psr6Store([
-            'cache_tags_header' => 'xkey',
+            'cache_tags_header' => TagHeaderFormatter::DEFAULT_HEADER_NAME,
             'cache_directory' => $this->cacheDir ?: $this->kernel->getCacheDir() . '/http_cache',
         ]);
     }
@@ -85,7 +86,7 @@ class AppCache extends HttpCache implements CacheInvalidation
     protected function cleanupHeadersForProd(Response $response)
     {
         // remove headers that identify the content or internal digest info
-        $response->headers->remove('xkey');
+        $response->headers->remove(TagHeaderFormatter::DEFAULT_HEADER_NAME);
         $response->headers->remove('x-content-digest');
 
         // remove vary by X-User-Hash header

--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -6,6 +6,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
+use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -35,6 +36,9 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
         $loader->load('services.yml');
         $loader->load('event.yml');
         $loader->load('view_cache.yml');
+
+        $this->setDefaultResponseHeader($container);
+        $this->setDefaultTagSeparator($container);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -63,5 +67,29 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
     public function getExtraConfigParsers()
     {
         return $this->extraConfigParsers;
+    }
+
+    /**
+     * Overrides default header name based on setting tag_mode in FosHttpCacheBundle configuration.
+     */
+    private function setDefaultResponseHeader(ContainerBuilder $container): void
+    {
+        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
+
+        $responseHeader = 'http' === $purgeType ? 'xkey' : TagHeaderFormatter::DEFAULT_HEADER_NAME;
+
+        $container->setParameter('fos_http_cache.tag_handler.response_header', $responseHeader);
+    }
+
+    /**
+     * Overrides default header separator based on setting tag_mode in FosHttpCacheBundle configuration.
+     */
+    private function setDefaultTagSeparator(ContainerBuilder $container): void
+    {
+        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
+
+        $separator = 'http' === $purgeType ? ' ' : ',';
+
+        $container->setParameter('fos_http_cache.tag_handler.separator', $separator);
     }
 }

--- a/src/EventSubscriber/UserContextSubscriber.php
+++ b/src/EventSubscriber/UserContextSubscriber.php
@@ -6,6 +6,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber;
 
 use EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix;
+use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -23,10 +24,12 @@ class UserContextSubscriber implements EventSubscriberInterface
     /**
      * @var string
      */
-    private $tagHeader = 'xkey';
+    private $tagHeader;
 
-    public function __construct(RepositoryTagPrefix $prefixService, $tagHeader)
-    {
+    public function __construct(
+        RepositoryTagPrefix $prefixService,
+        string $tagHeader = TagHeaderFormatter::DEFAULT_HEADER_NAME
+    ) {
         $this->prefixService = $prefixService;
         $this->tagHeader = $tagHeader;
     }

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -1,5 +1,4 @@
 parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
-    ezplatform.http_cache.tags.header: 'xkey'
     ezplatform.http_cache.invalidate_token.ttl: 86400
     ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']

--- a/src/Resources/config/fos_http_cache.yml
+++ b/src/Resources/config/fos_http_cache.yml
@@ -12,8 +12,3 @@ user_context:
     # NOTE: These are also defined/used in AppCache, in Varnish VCL, and Fastly VCL
     user_hash_header: X-User-Hash
     session_name_prefix: eZSESSID
-
-tags:
-    # Configure tag header for FosHttpCache
-    # See docs/using_tags.md for further info on usage
-    response_header: '%ezplatform.http_cache.tags.header%'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -52,17 +52,11 @@ services:
         arguments:
             - cache_directory: '%ezplatform.http_cache.store.root%'
 
-    ezplatform.http_cache.header_formatter.purge_type_based:
-        class: FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter
-        arguments:
-            - '%ezplatform.http_cache.tags.header%'
-            - "@=parameter('ezpublish.http_cache.purge_type') == 'local' ? ',' : ' '"
-
     ezplatform.http_cache.fos_tag_handler.xkey:
         class: EzSystems\PlatformHttpCacheBundle\Handler\TagHandler
         arguments:
          - '@ezplatform.http_cache.repository_tag_prefix'
-         - header_formatter: '@ezplatform.http_cache.header_formatter.purge_type_based'
+         - header_formatter: '@fos_http_cache.tag_handler.header_formatter'
            strict: '%fos_http_cache.tag_handler.strict%'
 
     ezplatform.http_cache.user_context_provider.role_identify:

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -22,7 +22,7 @@ services:
 
     ezplatform.user_context_tagger.response_subscriber:
         class: EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSubscriber
-        arguments: ['@ezplatform.http_cache.repository_tag_prefix', '%ezplatform.http_cache.tags.header%']
+        arguments: ['@ezplatform.http_cache.repository_tag_prefix', '%fos_http_cache.tag_handler.response_header%']
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30544](https://jira.ez.no/browse/EZP-30544)
| **Type**           | Improvement
| **Target version** | `master` for new features
| **BC breaks**      | yes
| **Doc needed**     | yes

Instead of relaying on `ezplatform.http_cache.tags.header` default fosCache tags are now used for local and varnish cache. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
