### PR TITLE
EZP-30814: Fixed extra %} in content_fields.html.twig

### DIFF
--- a/src/Resources/views/fields/content_fields.html.twig
+++ b/src/Resources/views/fields/content_fields.html.twig
@@ -3,7 +3,7 @@
 {% extends "EzPublishCoreBundle::content_fields.html.twig" %}
 
 {% block ezobjectrelationlist_field %}
-    {% apply spaceless %} %}
+    {% apply spaceless %}
         {% if not ez_field_is_empty( content, field ) %}
             <ul {{ block( 'field_attributes' ) }}>
                 {% for contentId in field.value.destinationContentIds %}
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block ezimageasset_field %}
-    {% apply spaceless %} %}
+    {% apply spaceless %}
         {% if not ez_field_is_empty(content, field) and parameters.available %}
             {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
             <div {{ block('field_attributes') }}>
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block ezobjectrelation_field %}
-    {% apply spaceless %} %}
+    {% apply spaceless %}
         {% if not ez_field_is_empty( content, field ) and parameters.available %}
             {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
             <div {{ block( 'field_attributes' ) }}>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30814](https://jira.ez.no/browse/EZP-30814)
| **Type**           | Bug
| **Target version** | `master`
| **BC breaks**      | no
| **Doc needed**     | no

Follow up for https://github.com/ezsystems/ezplatform-http-cache/pull/96. Fixed extra `%}` in  content_fields.html.twig. See https://github.com/ezsystems/ezplatform-http-cache/pull/96/files#r311497170

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests + specs and passing (`$ composer test`)~
- [ ] ~Fix new code according to Coding Standards (`$ composer fix-cs`).~
- [X] Ask for Code Review.
