### PR TITLE
EZP-30906: Removed deprecated templating component integration

### DIFF
--- a/src/Resources/views/fields/content_fields.html.twig
+++ b/src/Resources/views/fields/content_fields.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain "content_fields" %}
 
-{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+{% extends "@EzPublishCore/content_fields.html.twig" %}
 
 {% block ezobjectrelationlist_field %}
     {% apply spaceless %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30906](https://jira.ez.no/browse/EZP-30906)
| **Type**           | Improvement
| **Target version** |  `master`
| **BC breaks**      | no
| **Doc needed**     | no

main PR:
https://github.com/ezsystems/ezplatform/pull/453

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
