### PR TITLE
EZP-30934: Removed usage of deprecated getCurrentUser method

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -61,7 +61,10 @@ services:
 
     ezplatform.http_cache.user_context_provider.role_identify:
         class: EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify
-        arguments: ["@ezpublish.api.repository"]
+        arguments:
+            - '@ezpublish.api.repository'
+            - '@eZ\Publish\API\Repository\PermissionResolver'
+            - '@ezpublish.api.service.user'
         tags:
             - { name: fos_http_cache.user_context_provider }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30934](https://jira.ez.no/browse/EZP-30934)
| **Type**           | Improvement
| **Target version** |  `master`
| **BC breaks**      | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
