### PR TITLE
EZP-31113: AssignSectionToSubtree event is not handled by search and HTTP cache

### DIFF
--- a/src/EventSubscriber/CachePurge/LocationEventsSubscriber.php
+++ b/src/EventSubscriber/CachePurge/LocationEventsSubscriber.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Events\Location\MoveSubtreeEvent;
 use eZ\Publish\API\Repository\Events\Location\SwapLocationEvent;
 use eZ\Publish\API\Repository\Events\Location\UnhideLocationEvent;
 use eZ\Publish\API\Repository\Events\Location\UpdateLocationEvent;
+use eZ\Publish\API\Repository\Events\Section\AssignSectionToSubtreeEvent;
 
 final class LocationEventsSubscriber extends AbstractSubscriber
 {
@@ -30,6 +31,7 @@ final class LocationEventsSubscriber extends AbstractSubscriber
             SwapLocationEvent::class => 'onSwapLocation',
             UnhideLocationEvent::class => 'onUnhideLocation',
             UpdateLocationEvent::class => 'onUpdateLocation',
+            AssignSectionToSubtreeEvent::class => 'onAssignSectionToSubtree',
         ];
     }
 
@@ -161,7 +163,23 @@ final class LocationEventsSubscriber extends AbstractSubscriber
             $this->getContentTags((int)$contentId),
             $this->getLocationTags((int)$locationId),
             $this->getParentLocationTags((int)$parentLocationId),
-            );
+        );
+
+        $this->purgeClient->purge($tags);
+    }
+
+    public function onAssignSectionToSubtree(AssignSectionToSubtreeEvent $event): void
+    {
+        $location = $event->getLocation();
+
+        $tags = array_merge(
+            $this->getContentTags($location->contentId),
+            $this->getLocationTags($location->id),
+            $this->getParentLocationTags($location->parentLocationId),
+            [
+                'path-' . $location->id,
+            ]
+        );
 
         $this->purgeClient->purge($tags);
     }

--- a/src/EventSubscriber/CachePurge/LocationEventsSubscriber.php
+++ b/src/EventSubscriber/CachePurge/LocationEventsSubscriber.php
@@ -16,7 +16,6 @@ use eZ\Publish\API\Repository\Events\Location\MoveSubtreeEvent;
 use eZ\Publish\API\Repository\Events\Location\SwapLocationEvent;
 use eZ\Publish\API\Repository\Events\Location\UnhideLocationEvent;
 use eZ\Publish\API\Repository\Events\Location\UpdateLocationEvent;
-use eZ\Publish\API\Repository\Events\Section\AssignSectionToSubtreeEvent;
 
 final class LocationEventsSubscriber extends AbstractSubscriber
 {
@@ -31,7 +30,6 @@ final class LocationEventsSubscriber extends AbstractSubscriber
             SwapLocationEvent::class => 'onSwapLocation',
             UnhideLocationEvent::class => 'onUnhideLocation',
             UpdateLocationEvent::class => 'onUpdateLocation',
-            AssignSectionToSubtreeEvent::class => 'onAssignSectionToSubtree',
         ];
     }
 
@@ -163,22 +161,6 @@ final class LocationEventsSubscriber extends AbstractSubscriber
             $this->getContentTags((int)$contentId),
             $this->getLocationTags((int)$locationId),
             $this->getParentLocationTags((int)$parentLocationId),
-        );
-
-        $this->purgeClient->purge($tags);
-    }
-
-    public function onAssignSectionToSubtree(AssignSectionToSubtreeEvent $event): void
-    {
-        $location = $event->getLocation();
-
-        $tags = array_merge(
-            $this->getContentTags($location->contentId),
-            $this->getLocationTags($location->id),
-            $this->getParentLocationTags($location->parentLocationId),
-            [
-                'path-' . $location->id,
-            ]
         );
 
         $this->purgeClient->purge($tags);

--- a/src/EventSubscriber/CachePurge/SectionEventsSubscriber.php
+++ b/src/EventSubscriber/CachePurge/SectionEventsSubscriber.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge;
 
 use eZ\Publish\API\Repository\Events\Section\AssignSectionEvent;
+use eZ\Publish\API\Repository\Events\Section\AssignSectionToSubtreeEvent;
 use eZ\Publish\API\Repository\Events\Section\DeleteSectionEvent;
 use eZ\Publish\API\Repository\Events\Section\UpdateSectionEvent;
 
@@ -20,6 +21,7 @@ final class SectionEventsSubscriber extends AbstractSubscriber
             AssignSectionEvent::class => 'onAssignSection',
             DeleteSectionEvent::class => 'onDeleteSection',
             UpdateSectionEvent::class => 'onUpdateSection',
+            AssignSectionToSubtreeEvent::class => 'onAssignSectionToSubtree',
         ];
     }
 
@@ -51,5 +53,21 @@ final class SectionEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge([
             'section-' . $sectionId,
         ]);
+    }
+
+    public function onAssignSectionToSubtree(AssignSectionToSubtreeEvent $event): void
+    {
+        $location = $event->getLocation();
+
+        $tags = array_merge(
+            $this->getContentTags($location->contentId),
+            $this->getLocationTags($location->id),
+            $this->getParentLocationTags($location->parentLocationId),
+            [
+                'path-' . $location->id,
+            ]
+        );
+
+        $this->purgeClient->purge($tags);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31113](https://jira.ez.no/browse/EZP-31113)
| **Type**           | Bug
| **Target version** | `master`
| **BC breaks**      | no
| **Doc needed**     | no

https://github.com/ezsystems/ezplatform-http-cache/pull/106 for master

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Rebase after merge https://github.com/ezsystems/ezplatform-http-cache/pull/108
- [ ] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
