### PR TITLE
[WIP] EZP-30562: Hash tags with CRC32 in PROD to reduce cache tag sizes

### DIFF
--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -29,16 +29,16 @@ class TagHandlerSpec extends ObjectBehavior
         $this->beConstructedWith($cacheManager, 'xkey', $purgeClient, $tagPrefix);
     }
 
-    public function it_calls_purge_on_invalidate()
+    public function it_calls_purge_client_on_invalidate(PurgeClientInterface $purgeClient)
     {
-        $this->purge(Argument::exact(['something']));
+        $purgeClient->purge(Argument::exact(['something']))->shouldBeCalled();
 
         $this->invalidateTags(['something']);
     }
 
     public function it_calls_purge_client_on_purge(PurgeClientInterface $purgeClient)
     {
-        $purgeClient->purge(Argument::exact(['something']));
+        $purgeClient->purge(Argument::exact(['something']))->shouldBeCalled();
 
         $this->purge(['something']);
     }

--- a/src/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/PurgeClient/RepositoryPrefixDecorator.php
@@ -9,23 +9,34 @@ namespace EzSystems\PlatformHttpCacheBundle\PurgeClient;
 use EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix;
 
 /**
- * RepositoryPrefixDecorator decorates the real purge client in order to prefix tags with respository id.
+ * RepositoryPrefixDecorator decorates the real purge client in order to prefix tags with repository id.
+ *
+ * Also optionally allows for tags to be hashed to make sure tags are shortened (8 charters).
  *
  * Allows for multi repository usage against same proxy.
  */
 class RepositoryPrefixDecorator implements PurgeClientInterface
 {
-    /** @var \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface */
+    /**
+     * @var \EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface
+     */
     private $purgeClient;
+
     /**
      * @var \EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix
      */
     private $prefixService;
 
-    public function __construct(PurgeClientInterface $purgeClient, RepositoryTagPrefix $prefixService)
+    /**
+     * @var bool
+     */
+    private $hashTags;
+
+    public function __construct(PurgeClientInterface $purgeClient, RepositoryTagPrefix $prefixService, $hashTags = false)
     {
         $this->purgeClient = $purgeClient;
         $this->prefixService = $prefixService;
+        $this->hashTags = $hashTags;
     }
 
     public function purge($tags)
@@ -35,12 +46,17 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
         }
 
         $repoPrefix = $this->prefixService->getRepositoryPrefix();
+        $hashTags = $this->hashTags;
         $tags = array_map(
-            static function ($tag) use ($repoPrefix) {
+            static function ($tag) use ($repoPrefix, $hashTags) {
                 // Obsolete: for BC with older purge calls for BAN based HttpCache impl
                 $tag = is_numeric($tag) ? 'location-' . $tag : $tag;
 
                 // Prefix tags with repository prefix
+                if ($hashTags) {
+                    return hash('crc32b', $repoPrefix . $tag);
+                }
+
                 return $repoPrefix . $tag;
             },
             (array)$tags

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -3,5 +3,5 @@ parameters:
     ezplatform.http_cache.tags.header: 'xkey'
     ezplatform.http_cache.invalidate_token.ttl: 86400
     ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
-    # If enabled this hashes tags with hash('crc32b', $tag) in order to make sure tags are short
-    ezplatform.http_cache.tags.shorten_with_hash: "@=parameter('kernel.debug') ? false : true"
+    # Hashes tags with hash('crc32b', $tag) in order to make sure tags are short, by default used when !kernel.debug
+    ezplatform.http_cache.tags.shorten_with_hash: true

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -2,4 +2,5 @@ parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ezplatform.http_cache.tags.header: 'xkey'
     ezplatform.http_cache.invalidate_token.ttl: 86400
-    ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
+    # If enabled this hashes tags with hash('crc32b', $tag) in order to make sure tags are short
+    ezplatform.http_cache.tags.shorten_with_hash: "@=parameter('kernel.debug') ? false : true"

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -2,5 +2,6 @@ parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ezplatform.http_cache.tags.header: 'xkey'
     ezplatform.http_cache.invalidate_token.ttl: 86400
+    ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
     # If enabled this hashes tags with hash('crc32b', $tag) in order to make sure tags are short
     ezplatform.http_cache.tags.shorten_with_hash: "@=parameter('kernel.debug') ? false : true"

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -16,7 +16,10 @@ services:
 
     ezplatform.http_cache.purge_client_decorator:
         class: EzSystems\PlatformHttpCacheBundle\PurgeClient\RepositoryPrefixDecorator
-        arguments: ['@ezplatform.http_cache.purge_client_internal', '@ezplatform.http_cache.repository_tag_prefix']
+        arguments:
+            - '@ezplatform.http_cache.purge_client_internal'
+            - '@ezplatform.http_cache.repository_tag_prefix'
+            - '%ezplatform.http_cache.tags.shorten_with_hash%'
 
     ezplatform.http_cache.purge_client_internal:
         alias: ezplatform.http_cache.purge_client.local
@@ -50,6 +53,7 @@ services:
          - '%ezplatform.http_cache.tags.header%'
          - '@ezplatform.http_cache.purge_client'
          - '@ezplatform.http_cache.repository_tag_prefix'
+         - '%ezplatform.http_cache.tags.shorten_with_hash%'
 
     ezplatform.http_cache.user_context_provider.role_identify:
         class: EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,7 +19,7 @@ services:
         arguments:
             - '@ezplatform.http_cache.purge_client_internal'
             - '@ezplatform.http_cache.repository_tag_prefix'
-            - '%ezplatform.http_cache.tags.shorten_with_hash%'
+            - "@=container.getParameter('kernel.debug') ? false : parameter('ezplatform.http_cache.tags.shorten_with_hash')"
 
     ezplatform.http_cache.purge_client_internal:
         alias: ezplatform.http_cache.purge_client.local
@@ -53,7 +53,7 @@ services:
          - '%ezplatform.http_cache.tags.header%'
          - '@ezplatform.http_cache.purge_client'
          - '@ezplatform.http_cache.repository_tag_prefix'
-         - '%ezplatform.http_cache.tags.shorten_with_hash%'
+         - "@=container.getParameter('kernel.debug') ? false : parameter('ezplatform.http_cache.tags.shorten_with_hash')"
 
     ezplatform.http_cache.user_context_provider.role_identify:
         class: EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30562](https://jira.ez.no/browse/EZP-30562)
| **Type**           | Bug/Improvement
| **Target version** | 0.9
| **BC breaks**      | no
| **Doc needed**     | yes

This suggests to replace #86 for the following reasons:
- That one introduces shorter tags, but keeps old tags as well for BC which complicates the code a lot
    - Even with shorter tags they still continue to be rather long with repository prefix
- This is inspired by cache plugin for Wordpress, simply hashing the tag to keep it short
   - Picked CRC32 for this as it's 1. short 2. pretty fast 3. seems to be the one with short hash that avoids collisions the most _(some referred to it as 1 in 4 billion, at such level we don't care if we might sometimes in a full moon end up clearing a little bit too much cache as tag length is more of an issue..)_ 
   - Introduces setting for this and enables by default in prod, so dev continues to be readable _(as dev is not cached I assume this should be safe)_


WDYT @kmadejski @ITernovtsiy ?

Related to #104
Closes #86

**TODO**:
- [ ] 🗣 OPEN TOPIC: Should we adapt to also *purge* non hashed tags in 0.9 for BC? Otherwise we need to make it more clear people must clear **all** cache when deploying this change _(enabled)_
- [ ] Add Doc here and on doc.ezplatform.no
- [x] Implement feature / fix a bug.
- [ ] Add tests + specs and passing (`$ composer test`)
- [ ] Functional testing
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
