### PR TITLE
[1.0] Reduce Cache tag size by 40-70% & expand doc on how to deal with tags exceeding limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,13 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 5.6
-        - php: 7.0
         - php: 7.1
-          env: CHECK_CS=true
         - php: 7.2
+        - php: 7.3
+          env: CHECK_CS=true
         # Functional
-        - php: 7.0
-          env: TEST_CMD="bin/behat --profile=rest --tags=~@broken --suite=fullJson" EZPLATFORM_BRANCH=1.13 PHP_IMAGE=ezsystems/php:7.0-v1
         - php: 7.1
-          env: TEST_CMD="bin/behat --profile=rest --tags=~@broken --suite=fullJson"
+          env: TEST_CMD="bin/behat --profile=rest --tags=~@broken --suite=fullJson" PHP_IMAGE=ezsystems/php:7.1-v1
         - php: 7.2
           env: TEST_CMD="bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional" SYMFONY_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'" PHP_IMAGE=ezsystems/php:7.2-v1
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.3@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.5@dev",
         "friendsofsymfony/http-cache-bundle": "^1.3.13",
         "friendsofsymfony/http-cache": "^1.4.5",
         "symfony/symfony": "^2.8.40 || ^3.4.11"
@@ -41,8 +41,8 @@
     "extra": {
         "_ezplatform_branch_for_behat_tests": "2.5",
         "branch-alias": {
-            "dev-master": "0.9.x-dev",
-            "dev-tmp_ci_branch": "0.9.x-dev"
+            "dev-master": "1.0.x-dev",
+            "dev-tmp_ci_branch": "1.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,18 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.13.4@dev || ^7.5@dev",
-        "friendsofsymfony/http-cache-bundle": "^1.3.13",
+        "ezsystems/ezpublish-kernel": "^7.5@dev",
+        "friendsofsymfony/http-cache-bundle": "^1.3.16",
         "friendsofsymfony/http-cache": "^1.4.5",
-        "symfony/symfony": "^2.8.40 || ^3.4.11"
+        "symfony/symfony": "^3.4.37"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6.5.13",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.2.0 || ^2.3.1",
-        "phpspec/phpspec": "^3.4.3 || ^4.3.2",
+        "phpunit/phpunit": "^6.5.14 || ^7.5.20",
+        "matthiasnoback/symfony-dependency-injection-test": "^2.3.1",
+        "phpspec/phpspec": "^5.1.2",
         "ezsystems/ezplatform-code-style": "^0.1.0",
-        "friendsofphp/php-cs-fixer": "^2.16.0",
-        "memio/spec-gen": "^0.6.2 || ^0.8.5"
+        "friendsofphp/php-cs-fixer": "^2.16.1",
+        "memio/spec-gen": "^0.9.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -13,60 +13,71 @@ It works across all supported proxies _(see ["drivers"](drivers.md))_ by eZ Plat
 - [Fastly](https://www.fastly.com/) _(High performance reverse proxy, originally based on Varnish, worldwide as a CDN, driver available in eZ Platform Enterprise)_
 
 _In order to support several repositories on one installation, tags will be prefixed by
-repository name on non default repositories. E.g. "intranet_path-1"._
+repository index in use. I.e. 0p1", where "0" is the repository prefix._
 
-Varnish or Fastly are highly recommended for medium to large traffic needs. Besides being able to handle much more traffic, supported for use in cluster setup, they also both support soft purge _(by tags)_, meaning they are able to serve stale content while it's refreshed in the background on-demand, leading to more stable load on your backend.
+Varnish or Fastly are highly recommended for medium to large traffic needs. Besides being able to handle much more traffic,
+supported for use in cluster setup, they also both support soft purge _(by tags)_, meaning they are able to serve stale
+content while it's refreshed in the background on-demand, leading to more stable load on your backend.
+
 
 ## Tags in use in this bundle
 
 ### Tags for Content responses
 
-- `content-<content-id>` :
+- *Content*:\
+  `c<content-id>`:
   _Used on anything that is affected by changes to content, on content itself as well as location and so on._
 
-- `content-versions-<content-id>` :
-  _Used for clearing cache for content version list views, when not affecting the published content._
+- *Content Version*:\
+  `cv<content-id>`:
+  _Used for clearing cache for content version list views, when *not* affecting the published content._
 
-- `content-type-<content-type-id>` :
+- *Content Type*:\
+  `ct<content-type-id>`:
   _For use when content type changes affecting content of its type._
 
-- `location-<location-id>` :
+- *Location*:\
+  `l<location-id>`:
   _Used for clearing all cache relevant for a given location._
 
-- `parent-<parent-location-id>` :
-  _Used for clearing cache of all siblings of an location._
-
-- `parent-<location-id>` :
+- *Parent Location*:\
+  For responses this represent the parent location, on purges it's used in 2 distinct ways:\
+  `pl<parent-location-id>`:
+  _Used for clearing cache of all siblings of an location._\
+  `pl<location-id>`:
   _Used for clearing cache of all the children of a location._
 
-- `path-<location-id>` :
+- *Path* _(all path elements of a location)_:\
+  `p<location-id>`:
   _For operations that change the tree itself, like move/remove/(..)._
 
-- `relation-<content-id>` :
-- `relation-location-<location-id>` :
+- *Relations*:\
+  `r<content-id>` & `rl<location-id>`:
    _For use when updates affect all their reverse relations. ezplatform-http-cache does not add this tag to responses
    automatically, just purges on it if present, response tagging with this is currently done inline in template logic / views
-   where relation is actually used for rendering (when using ESI, if inline it's own tags will be added to response).
-   ezpublish-kernel add these as of v6.13.2/v7.1.0 on default relation templates)_
+   where relation is actually used for rendering (when using ESI, if inline the Content own tags should be added to response instead)._
 
 ### Tags for Section responses
 
-- `section-<section-id>` :
-  _For use when section changes affecting section reponses (i.e. REST)._
+- `s<section-id>` :
+  _For use when section changes affecting section responses (i.e. REST)._
 
 
 ### Tags for ContenType responses
 
-- `type-<content-type-id>` :
-  _For use when content type changes affecting content type reponses (i.e. REST)._
+- `t<content-type-id>` :
+  _For use when content type changes affecting content type responses (i.e. REST)._
 
-- `type-group-<content-type-id>` :
-  _For use when content type group changes affecting content type group reponses (i.e. REST)._
+- `tg<content-type-id>` :
+  _For use when content type group changes affecting content type group responses (i.e. REST)._
 
-### Misc
+### Misc internal tags
 
-- `ez-user-context-hash`
+- `ez-user-context-hash`:
    _Internal tag used for tagging /_fos_user_context_hash to expire it on role & role assigment changes._
+
+- `ez-invalidate-token`:
+  _Internal tag for use by token lookup when in token authentication mode (for setups where IP validation is not possible)._
 
 - `ez-all`:
    _Internal tag used for being able to clear all cache. Main use case is being able to expire (soft purge) all cache on
@@ -109,10 +120,10 @@ to tag your responses.
 
 For twig usage, you can make sure response is tagged correctly by using the following twig operator in your template:
 ```twig
-    {{ fos_httpcache_tag('relation-33') }}
+    {{ fos_httpcache_tag('r33') }}
 
     {# Or using array for several values #}
-    {{ fos_httpcache_tag(['relation-33', 'relation-44']) }}
+    {{ fos_httpcache_tag(['r33', 'r44']) }}
 ```
 
 See: http://foshttpcachebundle.readthedocs.io/en/1.3/features/tagging.html#tagging-from-twig-templates
@@ -127,7 +138,7 @@ Alternatively if you have a location(s) that you render inline & want invalidate
 Fo PHP usage, FOSHttpCache exposes `fos_http_cache.handler.tag_handler` service which lets you add tags to a response:
 ```php
     /** @var \FOS\HttpCache\Handler\TagHandler $tagHandler */
-    $tagHandler->addTags(['relation-33', 'relation-44']);
+    $tagHandler->addTags(['r33', 'r44']);
 ```
 
 See: http://foshttpcachebundle.readthedocs.io/en/1.3/features/tagging.html#tagging-from-code
@@ -149,27 +160,64 @@ E.g. on Move Location signal the following tags will be purged:
     {
         return [
             // The tree itself being moved (all children will have this tag)
-            'path-' . $signal->locationId,
+            'p' . $signal->locationId,
             // old parent
-            'location-' . $signal->oldParentLocationId,
+            'l' . $signal->oldParentLocationId,
             // old siblings
-            'parent-' . $signal->oldParentLocationId,
+            'pl' . $signal->oldParentLocationId,
             // new parent
-            'location-' . $signal->newParentLocationId,
+            'l' . $signal->newParentLocationId,
             // new siblings
-            'parent-' . $signal->newParentLocationId,
+            'pl' . $signal->newParentLocationId,
         ];
     }
 ```
 
-All slots can be found in `src/SignalSlot`.
-
+All slots can be found in `src/SignalSlot`
 
 ## Troubleshooting
 
-One common issue to encounter is that the tagging headers exceed limits in Varnish, stopping either caching or invalidation from happening:
-- [http_resp_hdr_len](https://varnish-cache.org/docs/6.0/reference/varnishd.html#http-resp-hdr-len) (e.g. 32k)
-- [http_max_hdr](https://varnish-cache.org/docs/6.0/reference/varnishd.html#http-max-hdr) (e.g. 128)
-- [http_resp_size](https://varnish-cache.org/docs/6.0/reference/varnishd.html#http-resp-size) (e.g. 64k)
+### Understanding tag response headers
 
-For more up-to-date info see online doc: https://doc.ezplatform.com/en/latest/guide/http_cache/#available-tags
+Given a header like `Xkey: 0c22 0ct2 (...)`, the following can be understood:
+- `Xkey:` Configured tag header, by this bundle config. Understood by Varnish _(with xkey module)_, and by our enhanced version of Symfony HttpCache Proxy "AppCache".
+- `0..`: Current repository index, set for you by this bundle. Done in order to support multi repository setups, it's the array key of the current repository is used _(and not the full identifier)_.
+- `..c22`: Content id 22
+- `..ct2`: Content Type id 2
+
+### Header limits
+
+Even if the tags are kept as short as possible, you might still encounter issue with tag header exceeding
+limits in Varnis/Apache/Nginx/Fastly, stopping either caching or invalidation from working as expected.
+
+For handling these cases it's simplest to increase the limits on the service side if possible, and if not look at the
+code involved to see if amount of tags can be reduced.
+
+#### Configuring Services
+
+*Varnish* config:
+- [http_resp_hdr_len](https://varnish-cache.org/docs/6.0/reference/varnishd.html#http-resp-hdr-len) (default 8k, change to i.e. 32k)
+- [http_max_hdr](https://varnish-cache.org/docs/6.0/reference/varnishd.html#http-max-hdr) (default 64, change to i.e. 128)
+- [http_resp_size](https://varnish-cache.org/docs/6.0/reference/varnishd.html#http-resp-size) (default 23k, change to i.e. 96k)
+- [workspace_backend](https://varnish-cache.org/docs/6.0/reference/varnishd.html#workspace-backend) (default 64k, change to i.e. 128k)
+
+*Fastly* has a `Surrogate-Key` header limit of *16kb*, this can *not* be changed.
+
+*Apache* has a [hard](https://github.com/apache/httpd/blob/5f32ea94af5f1e7ea68d6fca58f0ac2478cc18c5/server/util_script.c#L495) [coded](https://github.com/apache/httpd/blob/7e2d26eac309b2d79e467ef586526c10e0f226f8/include/httpd.h#L299-L303) limit of 8kb, so if you face this issue consider using nginx instead.
+
+*Nginx* has a default limit of 4k/8k when buffering responses from PHP-fpm/fast-cgi:
+- https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size
+- https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffer_size
+
+
+#### Limit tags header output by system
+
+Typical case with too many tags would be when inline rendering some form of embed content object.
+Normally the system will add all the tags for this content, to handle every possible scenario of updates to them.
+
+So if you embed hundreds of content on the same page _(in richtext, using relations, or using page builder)_, it will explode the tag usage.
+
+However if for instance you just display the content name, image attribute, and/or link, then it would be enough to:
+- Just use `r<id>` tag
+- Optionally: Set reduced cache TTL for the given view in order to reduce remote risk of subtree operations affecting the cached page
+  without correctly purging the view.

--- a/features/view_cache_tags.feature
+++ b/features/view_cache_tags.feature
@@ -5,17 +5,17 @@ Background:
 Scenario: Viewing a content item tags the Response
   Given a Content item
    When I view this Content item
-   Then the response is tagged with "content-<contentId>"
-    And the response is tagged with "location-<locationId>"
-    And the response is tagged with "content-type-<contentTypeId>"
+   Then the response is tagged with "c<contentId>"
+    And the response is tagged with "l<locationId>"
+    And the response is tagged with "ct<contentTypeId>"
 
 Scenario: Viewing a particular location of a content tags the Response with that location's ID
   Given a Content item with a secondary Location
    When I view the Content item from that location
-   Then the response is tagged with "location-<secondaryLocationId>"
+   Then the response is tagged with "l<secondaryLocationId>"
 
 Scenario: Viewing a content item with a relation with the default field template tags the Response
   Given a Content item with a filled relation field
     And the default template is used to render relation fields
    When I view this content item
-   Then the response is tagged with "relation-<relatedContentId>"
+   Then the response is tagged with "r<relatedContentId>"

--- a/spec/EventSubscriber/RestKernelViewSubscriberSpec.php
+++ b/spec/EventSubscriber/RestKernelViewSubscriberSpec.php
@@ -83,7 +83,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         $restValue->beConstructedWith([['id' => 5]]);
         $event->getControllerResult()->willReturn($restValue);
 
-        $tagHandler->addTags(['section-5'])->shouldBecalled();
+        $tagHandler->addTags(['s5'])->shouldBecalled();
         $event->setControllerResult(new TypeToken(CachedValue::class))->shouldBecalled();
 
         $this->tagUIRestResult($event);
@@ -124,7 +124,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         $restValue->beConstructedWith([['id' => 4, 'status' => ContentType::STATUS_DEFINED]]);
         $event->getControllerResult()->willReturn($restValue);
 
-        $tagHandler->addTags(['type-4'])->shouldBecalled();
+        $tagHandler->addTags(['t4'])->shouldBecalled();
         $event->setControllerResult(new TypeToken(CachedValue::class))->shouldBecalled();
 
         $this->tagUIRestResult($event);
@@ -169,7 +169,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         $restValue->contentType = $contentType;
         $event->getControllerResult()->willReturn($restValue);
 
-        $tagHandler->addTags(['type-4'])->shouldBecalled();
+        $tagHandler->addTags(['t4'])->shouldBecalled();
         $event->setControllerResult(new TypeToken(CachedValue::class))->shouldBecalled();
 
         $this->tagUIRestResult($event);
@@ -222,7 +222,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
 
         $event->getControllerResult()->willReturn($restValue);
 
-        $tagHandler->addTags(['type-4', 'type-group-2'])->shouldBecalled();
+        $tagHandler->addTags(['t4', 'tg2'])->shouldBecalled();
         $event->setControllerResult(new TypeToken(CachedValue::class))->shouldBecalled();
 
         $this->tagUIRestResult($event);
@@ -246,7 +246,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         $restValue->contentTypeGroups = [$contentTypeGroup];
         $event->getControllerResult()->willReturn($restValue);
 
-        $tagHandler->addTags(['type-group-2'])->shouldBecalled();
+        $tagHandler->addTags(['tg2'])->shouldBecalled();
         $event->setControllerResult(new TypeToken(CachedValue::class))->shouldBecalled();
 
         $this->tagUIRestResult($event);
@@ -272,7 +272,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         $restValue->versions = [$versionInfo];
         $event->getControllerResult()->willReturn($restValue);
 
-        $tagHandler->addTags(['content-33', 'content-versions-33'])->shouldBecalled();
+        $tagHandler->addTags(['c33', 'cv33'])->shouldBecalled();
         $event->setControllerResult(new TypeToken(CachedValue::class))->shouldBecalled();
 
         $this->tagUIRestResult($event);

--- a/spec/EventSubscriber/UserContextSubscriberSpec.php
+++ b/spec/EventSubscriber/UserContextSubscriberSpec.php
@@ -98,8 +98,8 @@ class UserContextSubscriberSpec extends ObjectBehavior
         $responseHeaders->get(Argument::exact('Content-Type'))->willReturn('application/vnd.fos.user-context-hash');
         $response->getTtl()->willReturn(100);
 
-        $prefixService->getRepositoryPrefix()->willReturn('intra_');
-        $responseHeaders->set(Argument::exact('xkey'), Argument::exact('intra_ez-user-context-hash'))->willReturn(null);
+        $prefixService->getRepositoryPrefix()->willReturn('1');
+        $responseHeaders->set(Argument::exact('xkey'), Argument::exact('1ez-user-context-hash'))->willReturn(null);
 
         $this->tagUserContext($event);
     }

--- a/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
@@ -61,14 +61,14 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
         );
 
         $tagHandler->addTags([
-            'location-123',
-            'parent-2',
-            'path-1',
-            'path-2',
-            'path-123',
-            'content-101',
-            'content-type-3',
-            'location-120',
+            'l123',
+            'pl2',
+            'p1',
+            'p2',
+            'p123',
+            'c101',
+            'ct3',
+            'l120',
         ])->shouldBecalled();
         $responseHeaders->remove('X-Location-Id')->shouldBecalled();
 
@@ -87,7 +87,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
 
         $repository->sudo(new AnyValueToken())->willThrow(new NotFoundException('id', 123));
 
-        $tagHandler->addTags(['location-123', 'path-123'])->shouldBecalled();
+        $tagHandler->addTags(['l123', 'p123'])->shouldBecalled();
         $responseHeaders->remove('X-Location-Id')->shouldBecalled();
 
         $this->rewriteCacheHeader($event);
@@ -105,7 +105,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
 
         $repository->sudo(new AnyValueToken())->willThrow(new NotFoundException('id', 123));
 
-        $tagHandler->addTags(['location-123', 'path-123', 'location-34', 'path-34'])->shouldBecalled();
+        $tagHandler->addTags(['l123', 'p123', 'l34', 'p34'])->shouldBecalled();
         $responseHeaders->remove('X-Location-Id')->shouldBecalled();
 
         $this->rewriteCacheHeader($event);

--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -88,50 +88,32 @@ class TagHandlerSpec extends ObjectBehavior
 
     public function it_tags_all_tags_we_add(Response $response, ResponseHeaderBag $responseHeaderBag)
     {
-        $responseHeaderBag->set('xkey', Argument::exact('ez-all location-4 content-4 path-2'))->shouldBeCalled();
+        $responseHeaderBag->set('xkey', Argument::exact('ez-all l4 c4 p2'))->shouldBeCalled();
 
-        $this->addTags(['location-4', 'content-4']);
-        $this->addTags(['path-2']);
-        $this->tagResponse($response, true);
-    }
-
-    public function it_tags_all_tags_we_add_on_null_RepositoryId(Response $response, ResponseHeaderBag $responseHeaderBag)
-    {
-        $responseHeaderBag->set('xkey', Argument::exact('ez-all location-4 content-4 path-2'))->shouldBeCalled();
-
-        $this->addTags(['location-4', 'content-4']);
-        $this->addTags(['path-2']);
-        $this->tagResponse($response, true);
-    }
-
-    public function it_tags_all_tags_we_add_on_default_RepositoryId(Response $response, ResponseHeaderBag $responseHeaderBag)
-    {
-        $responseHeaderBag->set('xkey', Argument::exact('ez-all location-4 content-4 path-2'))->shouldBeCalled();
-
-        $this->addTags(['location-4', 'content-4']);
-        $this->addTags(['path-2']);
+        $this->addTags(['l4', 'c4']);
+        $this->addTags(['p2']);
         $this->tagResponse($response, true);
     }
 
     public function it_tags_all_tags_we_add_and_prefix_with_repo_id(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix)
     {
-        $tagPrefix->getRepositoryPrefix()->willReturn('intranet_');
-        $responseHeaderBag->set('xkey', Argument::exact('intranet_ez-all intranet_location-4 intranet_content-4 intranet_path-2 ez-all'))->shouldBeCalled();
+        $tagPrefix->getRepositoryPrefix()->willReturn('0');
+        $responseHeaderBag->set('xkey', Argument::exact('0ez-all 0l4 0c4 0p2 ez-all'))->shouldBeCalled();
 
-        $this->addTags(['location-4', 'content-4']);
-        $this->addTags(['path-2']);
+        $this->addTags(['l4', 'c4']);
+        $this->addTags(['p2']);
         $this->tagResponse($response, true);
     }
 
     public function it_tags_all_tags_we_add_and_prefix_with_repo_id_also_with_existing_header(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix)
     {
-        $tagPrefix->getRepositoryPrefix()->willReturn('intranet_');
+        $tagPrefix->getRepositoryPrefix()->willReturn('2');
         $responseHeaderBag->has('xkey')->willReturn(true);
         $responseHeaderBag->get('xkey', null, false)->willReturn(['tag1']);
-        $responseHeaderBag->set('xkey', Argument::exact('intranet_tag1 intranet_ez-all intranet_location-4 intranet_content-4 intranet_path-2 ez-all'))->shouldBeCalled();
+        $responseHeaderBag->set('xkey', Argument::exact('2tag1 2ez-all 2l4 2c4 2p2 ez-all'))->shouldBeCalled();
 
-        $this->addTags(['location-4', 'content-4']);
-        $this->addTags(['path-2']);
+        $this->addTags(['l4', 'c4']);
+        $this->addTags(['p2']);
         $this->tagResponse($response, false);
     }
 }

--- a/spec/RepositoryTagPrefixSpec.php
+++ b/spec/RepositoryTagPrefixSpec.php
@@ -11,7 +11,7 @@ class RepositoryTagPrefixSpec extends ObjectBehavior
 {
     public function let(ConfigResolverInterface $resolver)
     {
-        $this->beConstructedWith($resolver, ['default' => [], 'intra' => []]);
+        $this->beConstructedWith($resolver, ['default' => [], 'intra' => [], 'site' => []]);
     }
 
     function it_is_initializable()
@@ -37,13 +37,13 @@ class RepositoryTagPrefixSpec extends ObjectBehavior
     {
         $resolver->getParameter(Argument::exact('repository'))->willReturn('intra');
 
-        $this->getRepositoryPrefix()->shouldReturn('intra_');
+        $this->getRepositoryPrefix()->shouldReturn('1');
     }
 
     public function it_returns_value_on_non_default_cross_check(ConfigResolverInterface $resolver)
     {
         $resolver->getParameter(Argument::exact('repository'))->willReturn('site');
 
-        $this->getRepositoryPrefix()->shouldReturn('site_');
+        $this->getRepositoryPrefix()->shouldReturn('2');
     }
 }

--- a/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
+++ b/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
@@ -32,7 +32,7 @@ class ContentInfoTaggerSpec extends ObjectBehavior
 
         $this->tag($value);
 
-        $tagHandler->addTags(['content-123', 'content-type-987'])->shouldHaveBeenCalled();
+        $tagHandler->addTags(['c123', 'ct987'])->shouldHaveBeenCalled();
     }
 
     public function it_tags_with_location_id_if_one_is_set(TagHandler $tagHandler)
@@ -41,6 +41,6 @@ class ContentInfoTaggerSpec extends ObjectBehavior
 
         $this->tag($value);
 
-        $tagHandler->addTags(['location-456'])->shouldHaveBeenCalled();
+        $tagHandler->addTags(['l456'])->shouldHaveBeenCalled();
     }
 }

--- a/spec/ResponseTagger/Value/LocationTaggerSpec.php
+++ b/spec/ResponseTagger/Value/LocationTaggerSpec.php
@@ -33,7 +33,7 @@ class LocationTaggerSpec extends ObjectBehavior
         $value = new Location(['id' => 123, 'contentInfo' => new ContentInfo(['mainLocationId' => 321])]);
         $this->tag($value);
 
-        $tagHandler->addTags(['location-123'])->shouldHaveBeenCalled();
+        $tagHandler->addTags(['l123'])->shouldHaveBeenCalled();
     }
 
     public function it_tags_with_parent_location_id(TagHandler $tagHandler)
@@ -42,7 +42,7 @@ class LocationTaggerSpec extends ObjectBehavior
 
         $this->tag($value);
 
-        $tagHandler->addTags(['parent-123'])->shouldHaveBeenCalled();
+        $tagHandler->addTags(['pl123'])->shouldHaveBeenCalled();
     }
 
     public function it_tags_with_path_items(TagHandler $tagHandler)
@@ -51,6 +51,6 @@ class LocationTaggerSpec extends ObjectBehavior
 
         $this->tag($value);
 
-        $tagHandler->addTags(['path-1', 'path-2', 'path-123'])->shouldHaveBeenCalled();
+        $tagHandler->addTags(['p1', 'p2', 'p123'])->shouldHaveBeenCalled();
     }
 }

--- a/src/EventSubscriber/RestKernelViewSubscriber.php
+++ b/src/EventSubscriber/RestKernelViewSubscriber.php
@@ -71,23 +71,23 @@ class RestKernelViewSubscriber implements EventSubscriberInterface
         $tags = [];
         switch ($value) {
             case $value instanceof VersionList && !empty($value->versions):
-                $tags[] = 'content-' . $value->versions[0]->contentInfo->id;
-                $tags[] = 'content-versions-' . $value->versions[0]->contentInfo->id;
+                $tags[] = 'c' . $value->versions[0]->contentInfo->id;
+                $tags[] = 'cv' . $value->versions[0]->contentInfo->id;
 
                 break;
 
             case $value instanceof Section:
-                $tags[] = 'section-' . $value->id;
+                $tags[] = 's' . $value->id;
                 break;
 
             case $value instanceof ContentTypeGroupRefList:
                 if ($value->contentType->status !== ContentType::STATUS_DEFINED) {
                     return [];
                 }
-                $tags[] = 'type-' . $value->contentType->id;
+                $tags[] = 't' . $value->contentType->id;
             case $value instanceof ContentTypeGroupList:
                 foreach ($value->contentTypeGroups as $contentTypeGroup) {
-                    $tags[] = 'type-group-' . $contentTypeGroup->id;
+                    $tags[] = 'tg' . $contentTypeGroup->id;
                 }
                 break;
 
@@ -97,7 +97,7 @@ class RestKernelViewSubscriber implements EventSubscriberInterface
                 if ($value->status !== ContentType::STATUS_DEFINED) {
                     return [];
                 }
-                $tags[] = 'type-' . $value->id;
+                $tags[] = 't' . $value->id;
                 break;
 
             case $value instanceof Root:
@@ -106,19 +106,19 @@ class RestKernelViewSubscriber implements EventSubscriberInterface
 
                 // @deprecated The following logic is 1.x specific, and should be removed before a 1.0 version
             case $value instanceof PermissionReport:
-                // We requrie v0.1.5 with added location property to be able to add tags
+                // We require v0.1.5 with added location property to be able to add tags
                 if (!isset($value->parentLocation)) {
                     return [];
                 }
 
                 // In case of for instance location swap where content type might change affecting allowed content types
-                $tags[] = 'content-' . $value->parentLocation->contentId;
-                $tags[] = 'content-type-' . $value->parentLocation->contentInfo->contentTypeId;
-                $tags[] = 'location-' . $value->parentLocation->id;
+                $tags[] = 'c' . $value->parentLocation->contentId;
+                $tags[] = 'ct' . $value->parentLocation->contentInfo->contentTypeId;
+                $tags[] = 'l' . $value->parentLocation->id;
 
                 // In case of permissions assigned by subtree, so if path changes affecting this (move subtree operation)
                 foreach ($value->parentLocation->path as $pathItem) {
-                    $tags[] = 'path-' . $pathItem;
+                    $tags[] = 'p' . $pathItem;
                 }
                 break;
         }

--- a/src/EventSubscriber/XLocationIdResponseSubscriber.php
+++ b/src/EventSubscriber/XLocationIdResponseSubscriber.php
@@ -60,27 +60,27 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
             $id = trim($id);
             try {
                 /** @var $location \eZ\Publish\API\Repository\Values\Content\Location */
-                $location = $this->repository->sudo(function (Repository $repository) use ($id) {
+                $location = $this->repository->sudo(static function (Repository $repository) use ($id) {
                     return $repository->getLocationService()->loadLocation($id);
                 });
 
-                $tags[] = 'location-' . $location->id;
-                $tags[] = 'parent-' . $location->parentLocationId;
+                $tags[] = 'l' . $location->id;
+                $tags[] = 'pl' . $location->parentLocationId;
 
                 foreach ($location->path as $pathItem) {
-                    $tags[] = 'path-' . $pathItem;
+                    $tags[] = 'p' . $pathItem;
                 }
 
                 $contentInfo = $location->getContentInfo();
-                $tags[] = 'content-' . $contentInfo->id;
-                $tags[] = 'content-type-' . $contentInfo->contentTypeId;
+                $tags[] = 'c' . $contentInfo->id;
+                $tags[] = 'ct' . $contentInfo->contentTypeId;
 
                 if ($contentInfo->mainLocationId !== $location->id) {
-                    $tags[] = 'location-' . $contentInfo->mainLocationId;
+                    $tags[] = 'l' . $contentInfo->mainLocationId;
                 }
             } catch (NotFoundException $e) {
-                $tags[] = "location-$id";
-                $tags[] = "path-$id";
+                $tags[] = "l$id";
+                $tags[] = "p$id";
             }
         }
 

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -22,7 +22,6 @@ use FOS\HttpCacheBundle\CacheManager;
  */
 class TagHandler extends FOSTagHandler
 {
-    private $cacheManager;
     private $purgeClient;
     private $prefixService;
     private $tagsHeader;
@@ -33,7 +32,6 @@ class TagHandler extends FOSTagHandler
         PurgeClientInterface $purgeClient,
         RepositoryTagPrefix $prefixService
     ) {
-        $this->cacheManager = $cacheManager;
         $this->tagsHeader = $tagsHeader;
         $this->purgeClient = $purgeClient;
         $this->prefixService = $prefixService;
@@ -69,16 +67,14 @@ class TagHandler extends FOSTagHandler
 
             // Prefix tags with repository prefix (to be able to support several repositories on one proxy)
             $repoPrefix = $this->prefixService->getRepositoryPrefix();
-            if (!empty($repoPrefix)) {
-                $tags = array_map(
-                    static function ($tag) use ($repoPrefix) {
-                        return $repoPrefix . $tag;
-                    },
-                    $tags
-                );
-                // Also add a un-prefixed `ez-all` in order to be able to purge all across repos
-                $tags[] = 'ez-all';
-            }
+            $tags = array_map(
+                static function ($tag) use ($repoPrefix) {
+                    return $repoPrefix . $tag;
+                },
+                $tags
+            );
+            // Also add a un-prefixed `ez-all` in order to be able to purge all across repos
+            $tags[] = 'ez-all';
 
             $response->headers->set($this->tagsHeader, implode(' ', array_unique($tags)));
         }

--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -146,11 +146,11 @@ class TagAwareStore extends Store implements RequestAwarePurger
         } elseif ($locationId[0] === '(' && substr($locationId, -1) === ')') {
             // Deprecated: (123|456|789) => Purge for #123, #456 and #789 location IDs.
             $tags = array_map(
-                function ($id) {return 'location-' . $id;},
+                static function ($id) {return 'l' . $id;},
                 explode('|', substr($locationId, 1, -1))
             );
         } else {
-            $tags = ['location-' . $locationId];
+            $tags = ['l' . $locationId];
         }
 
         if (empty($tags)) {
@@ -214,7 +214,16 @@ class TagAwareStore extends Store implements RequestAwarePurger
             // Flip the tag so we put id first so it gets sliced into folders.
             // (otherwise we would easily reach inode limits on file system)
             $tag = strrev($tag);
-            $path .= \DIRECTORY_SEPARATOR . substr($tag, 0, 2) . \DIRECTORY_SEPARATOR . substr($tag, 2, 2) . \DIRECTORY_SEPARATOR . substr($tag, 4);
+            $length = strlen($tag);
+            $path .= \DIRECTORY_SEPARATOR . substr($tag, 0, 2);
+
+            if ($length > 2) {
+                $path .= \DIRECTORY_SEPARATOR . substr($tag, 2, 2);
+            }
+
+            if ($length > 4) {
+                $path .= \DIRECTORY_SEPARATOR . substr($tag, 4);
+            }
         }
 
         return $path;

--- a/src/PurgeClient/LocalPurgeClient.php
+++ b/src/PurgeClient/LocalPurgeClient.php
@@ -32,8 +32,8 @@ class LocalPurgeClient implements PurgeClientInterface
         }
 
         $tags = array_map(
-            function ($tag) {
-                return is_numeric($tag) ? 'location-' . $tag : $tag;
+            static function ($tag) {
+                return is_numeric($tag) ? 'l' . $tag : $tag;
             },
             (array)$tags
         );

--- a/src/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/PurgeClient/RepositoryPrefixDecorator.php
@@ -38,7 +38,7 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
         $tags = array_map(
             static function ($tag) use ($repoPrefix) {
                 // Obsolete: for BC with older purge calls for BAN based HttpCache impl
-                $tag = is_numeric($tag) ? 'location-' . $tag : $tag;
+                $tag = is_numeric($tag) ? 'l' . $tag : $tag;
 
                 // Prefix tags with repository prefix
                 return $repoPrefix . $tag;
@@ -51,6 +51,7 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
 
     public function purgeAll()
     {
+        //  No prefix here, this on purpose clears all as use case is deployment of whole install.
         $this->purgeClient->purgeAll();
     }
 }

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -48,7 +48,7 @@ class VarnishPurgeClient implements PurgeClientInterface
 
         // For 5.4/1.x BC make sure to map any int to location id tag
         $tags = array_unique(array_map(static function ($tag) {
-            return is_numeric($tag) ? 'location-' . $tag : $tag;
+            return is_numeric($tag) ? 'l' . $tag : $tag;
         },
             (array)$tags
         ));
@@ -56,7 +56,7 @@ class VarnishPurgeClient implements PurgeClientInterface
         $headers = $this->getPurgeHeaders();
         $chunkSize = $this->determineTagsPerHeader($tags);
 
-        // NB! This requries varnish-modules 0.10.2, if you need support for varnish-modules 0.9.x, use ezplatform-http-cache 0.8.x
+        // NB! This requires varnish-modules 0.10.2, if you need support for varnish-modules 0.9.x, use ezplatform-http-cache 0.8.x
         foreach (array_chunk($tags, $chunkSize) as $tagchunk) {
             $headers['key'] = implode(' ', $tagchunk);
             $this->cacheManager->invalidatePath(

--- a/src/RepositoryTagPrefix.php
+++ b/src/RepositoryTagPrefix.php
@@ -21,24 +21,26 @@ class RepositoryTagPrefix
     private $resolver;
 
     /**
-     * @var string
+     * @var int[<string>]
      */
-    private $defaultRepository = '';
+    private $repositoryMap = [];
 
     public function __construct(ConfigResolverInterface $resolver, array $repositories)
     {
         $this->resolver = $resolver;
 
-        // First repositories is the default one, foreach is apparently the fastest way to get it.
-        foreach ($repositories as $repositoryId => $value) {
-            $this->defaultRepository = $repositoryId;
-
-            break;
+        // Build a map of repository identifier <> array index, as we will return the latter as prefix
+        $i = 0;
+        foreach ($repositories as $repositoryIdentifier => $value) {
+            $this->repositoryMap[$repositoryIdentifier] = $i === 0 ? '' : $i;
+            ++$i;
         }
     }
 
     /**
-     * Return repository prefix, either '' if default or '<repositoryId>_' if not default repository.
+     * Return repository prefix, specifically the index number in the array of repositories.
+     *
+     * Example: Default repository (first one), will return value ""
      *
      * WARNING: Must be called on-demand and not in constructors to avoid any issues with SiteAccess scope changes.
      *
@@ -46,8 +48,8 @@ class RepositoryTagPrefix
      */
     public function getRepositoryPrefix()
     {
-        $repositoryId = $this->resolver->getParameter('repository');
+        $repositoryIdentifier = $this->resolver->getParameter('repository');
 
-        return empty($repositoryId) || $repositoryId === $this->defaultRepository ? '' : $repositoryId . '_';
+        return (string) (empty($repositoryIdentifier) ? '' : $this->repositoryMap[$repositoryIdentifier]);
     }
 }

--- a/src/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/ResponseTagger/Value/ContentInfoTagger.php
@@ -16,10 +16,10 @@ class ContentInfoTagger extends AbstractValueTagger
             return $this;
         }
 
-        $this->tagHandler->addTags(['content-' . $value->id, 'content-type-' . $value->contentTypeId]);
+        $this->tagHandler->addTags(['c' . $value->id, 'ct' . $value->contentTypeId]);
 
         if ($value->mainLocationId) {
-            $this->tagHandler->addTags(['location-' . $value->mainLocationId]);
+            $this->tagHandler->addTags(['l' . $value->mainLocationId]);
         }
     }
 }

--- a/src/ResponseTagger/Value/LocationTagger.php
+++ b/src/ResponseTagger/Value/LocationTagger.php
@@ -17,14 +17,14 @@ class LocationTagger extends AbstractValueTagger
         }
 
         if ($value->id !== $value->contentInfo->mainLocationId) {
-            $this->tagHandler->addTags(['location-' . $value->id]);
+            $this->tagHandler->addTags(['l' . $value->id]);
         }
 
-        $this->tagHandler->addTags(['parent-' . $value->parentLocationId]);
+        $this->tagHandler->addTags(['pl' . $value->parentLocationId]);
         $this->tagHandler->addTags(
             array_map(
-                function ($pathItem) {
-                    return 'path-' . $pathItem;
+                static function ($pathItem) {
+                    return 'p' . $pathItem;
                 },
                 $value->path
             )

--- a/src/SignalSlot/AbstractContentSlot.php
+++ b/src/SignalSlot/AbstractContentSlot.php
@@ -34,6 +34,10 @@ abstract class AbstractContentSlot extends AbstractSlot
             $tags[] = 'c' . $signal->contentId;
             // reverse relations
             $tags[] = 'r' . $signal->contentId;
+
+            // deprecated
+            $tags[] = 'content-' . $signal->contentId;
+            $tags[] = 'relation-' . $signal->contentId;
         }
 
         if (isset($signal->locationId)) {
@@ -43,6 +47,11 @@ abstract class AbstractContentSlot extends AbstractSlot
             $tags[] = 'pl' . $signal->locationId;
             // reverse location relations
             $tags[] = 'rl' . $signal->locationId;
+
+            // deprecated
+            $tags[] = 'location-' . $signal->locationId;
+            $tags[] = 'parent-' . $signal->locationId;
+            $tags[] = 'relation-location-' . $signal->locationId;
         }
 
         if (isset($signal->parentLocationId)) {
@@ -50,6 +59,10 @@ abstract class AbstractContentSlot extends AbstractSlot
             $tags[] = 'l' . $signal->parentLocationId;
             // direct siblings
             $tags[] = 'pl' . $signal->parentLocationId;
+
+            // deprecated
+            $tags[] = 'location-' . $signal->parentLocationId;
+            $tags[] = 'parent-' . $signal->parentLocationId;
         }
 
         return $tags;

--- a/src/SignalSlot/AbstractContentSlot.php
+++ b/src/SignalSlot/AbstractContentSlot.php
@@ -31,25 +31,25 @@ abstract class AbstractContentSlot extends AbstractSlot
 
         if (isset($signal->contentId)) {
             // self in all forms (also without locations)
-            $tags[] = 'content-' . $signal->contentId;
+            $tags[] = 'c' . $signal->contentId;
             // reverse relations
-            $tags[] = 'relation-' . $signal->contentId;
+            $tags[] = 'r' . $signal->contentId;
         }
 
         if (isset($signal->locationId)) {
             // self
-            $tags[] = 'location-' . $signal->locationId;
+            $tags[] = 'l' . $signal->locationId;
             // direct children
-            $tags[] = 'parent-' . $signal->locationId;
+            $tags[] = 'pl' . $signal->locationId;
             // reverse location relations
-            $tags[] = 'relation-location-' . $signal->locationId;
+            $tags[] = 'rl' . $signal->locationId;
         }
 
         if (isset($signal->parentLocationId)) {
             // direct parent
-            $tags[] = 'location-' . $signal->parentLocationId;
+            $tags[] = 'l' . $signal->parentLocationId;
             // direct siblings
-            $tags[] = 'parent-' . $signal->parentLocationId;
+            $tags[] = 'pl' . $signal->parentLocationId;
         }
 
         return $tags;

--- a/src/SignalSlot/AbstractPublishSlot.php
+++ b/src/SignalSlot/AbstractPublishSlot.php
@@ -42,22 +42,22 @@ abstract class AbstractPublishSlot extends AbstractContentSlot
 
         $tags = [
             // self in all forms (also without locations)
-            'content-' . $contentId,
+            'c' . $contentId,
             // reverse relations
-            'relation-' . $contentId,
+            'r' . $contentId,
         ];
 
         foreach ($this->locationHandler->loadLocationsByContent($contentId) as $location) {
             // self
-            $tags[] = 'location-' . $location->id;
+            $tags[] = 'l' . $location->id;
             // children
-            $tags[] = 'parent-' . $location->id;
+            $tags[] = 'pl' . $location->id;
             // reverse location relations
-            $tags[] = 'relation-location-' . $location->id;
+            $tags[] = 'rl' . $location->id;
             // parent
-            $tags[] = 'location-' . $location->parentId;
+            $tags[] = 'l' . $location->parentId;
             // siblings
-            $tags[] = 'parent-' . $location->parentId;
+            $tags[] = 'pl' . $location->parentId;
         }
 
         return $tags;

--- a/src/SignalSlot/AbstractPublishSlot.php
+++ b/src/SignalSlot/AbstractPublishSlot.php
@@ -45,6 +45,10 @@ abstract class AbstractPublishSlot extends AbstractContentSlot
             'c' . $contentId,
             // reverse relations
             'r' . $contentId,
+
+            // deprecated
+            'content-' . $contentId,
+            'relation-' . $contentId,
         ];
 
         foreach ($this->locationHandler->loadLocationsByContent($contentId) as $location) {
@@ -54,10 +58,20 @@ abstract class AbstractPublishSlot extends AbstractContentSlot
             $tags[] = 'pl' . $location->id;
             // reverse location relations
             $tags[] = 'rl' . $location->id;
+
+            // deprecated
+            $tags[] = 'location-' . $location->id;
+            $tags[] = 'parent-' . $location->id;
+            $tags[] = 'relation-location-' . $location->id;
+
             // parent
             $tags[] = 'l' . $location->parentId;
             // siblings
             $tags[] = 'pl' . $location->parentId;
+
+            // deprecated
+            $tags[] = 'location-' . $location->parentId;
+            $tags[] = 'parent-' . $location->parentId;
         }
 
         return $tags;

--- a/src/SignalSlot/AssignUserToUserGroupSlot.php
+++ b/src/SignalSlot/AssignUserToUserGroupSlot.php
@@ -18,7 +18,15 @@ class AssignUserToUserGroupSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['c' . $signal->userId, 'c' . $signal->userGroupId, 'ez-user-context-hash'];
+        return [
+            'c' . $signal->userId,
+            'c' . $signal->userGroupId,
+            'ez-user-context-hash',
+
+            // deprecated
+            'content-' . $signal->userId,
+            'content-' . $signal->userGroupId,
+        ];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/AssignUserToUserGroupSlot.php
+++ b/src/SignalSlot/AssignUserToUserGroupSlot.php
@@ -18,7 +18,7 @@ class AssignUserToUserGroupSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId, 'ez-user-context-hash'];
+        return ['c' . $signal->userId, 'c' . $signal->userGroupId, 'ez-user-context-hash'];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/ContentTypeService/AssignContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/AssignContentTypeGroupSlot.php
@@ -24,6 +24,6 @@ class AssignContentTypeGroupSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return ['tg' . $signal->contentTypeGroupId];
     }
 }

--- a/src/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlot.php
@@ -24,6 +24,6 @@ class DeleteContentTypeGroupSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return ['tg' . $signal->contentTypeGroupId];
     }
 }

--- a/src/SignalSlot/ContentTypeService/DeleteContentTypeSlot.php
+++ b/src/SignalSlot/ContentTypeService/DeleteContentTypeSlot.php
@@ -24,6 +24,6 @@ class DeleteContentTypeSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-type-' . $signal->contentTypeId, 'type-' . $signal->contentTypeId];
+        return ['ct' . $signal->contentTypeId, 't' . $signal->contentTypeId];
     }
 }

--- a/src/SignalSlot/ContentTypeService/PublishContentTypeSlot.php
+++ b/src/SignalSlot/ContentTypeService/PublishContentTypeSlot.php
@@ -24,6 +24,6 @@ class PublishContentTypeSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-type-' . $signal->contentTypeDraftId, 'type-' . $signal->contentTypeDraftId];
+        return ['ct' . $signal->contentTypeDraftId, 't' . $signal->contentTypeDraftId];
     }
 }

--- a/src/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlot.php
@@ -24,6 +24,6 @@ class UnassignContentTypeGroupSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return ['tg' . $signal->contentTypeGroupId];
     }
 }

--- a/src/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlot.php
+++ b/src/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlot.php
@@ -24,6 +24,6 @@ class UpdateContentTypeGroupSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['type-group-' . $signal->contentTypeGroupId];
+        return ['tg' . $signal->contentTypeGroupId];
     }
 }

--- a/src/SignalSlot/CopyContentSlot.php
+++ b/src/SignalSlot/CopyContentSlot.php
@@ -18,7 +18,7 @@ class CopyContentSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-' . $signal->dstContentId, 'location-' . $signal->dstParentLocationId, 'path-' . $signal->dstParentLocationId];
+        return ['c' . $signal->dstContentId, 'l' . $signal->dstParentLocationId, 'p' . $signal->dstParentLocationId];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/CopyContentSlot.php
+++ b/src/SignalSlot/CopyContentSlot.php
@@ -18,7 +18,11 @@ class CopyContentSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['c' . $signal->dstContentId, 'l' . $signal->dstParentLocationId, 'p' . $signal->dstParentLocationId];
+        return [
+            'c' . $signal->dstContentId, 'l' . $signal->dstParentLocationId, 'p' . $signal->dstParentLocationId,
+            // deprecated
+            'content-' . $signal->dstContentId, 'location-' . $signal->dstParentLocationId, 'path-' . $signal->dstParentLocationId,
+        ];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/CopySubtreeSlot.php
+++ b/src/SignalSlot/CopySubtreeSlot.php
@@ -18,9 +18,9 @@ class CopySubtreeSlot extends AbstractContentSlot
         /** @var \eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal $signal */
         return [
             // parent of the new copied tree
-            'location-' . $signal->targetParentLocationId,
+            'l' . $signal->targetParentLocationId,
             // siblings of the new copied tree
-            'parent-' . $signal->targetParentLocationId,
+            'pl' . $signal->targetParentLocationId,
         ];
     }
 

--- a/src/SignalSlot/CopySubtreeSlot.php
+++ b/src/SignalSlot/CopySubtreeSlot.php
@@ -21,6 +21,10 @@ class CopySubtreeSlot extends AbstractContentSlot
             'l' . $signal->targetParentLocationId,
             // siblings of the new copied tree
             'pl' . $signal->targetParentLocationId,
+
+            // deprecated
+            'location-' . $signal->targetParentLocationId,
+            'parent-' . $signal->targetParentLocationId,
         ];
     }
 

--- a/src/SignalSlot/CreateContentDraftSlot.php
+++ b/src/SignalSlot/CreateContentDraftSlot.php
@@ -23,6 +23,6 @@ class CreateContentDraftSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-versions-' . $signal->contentId];
+        return ['cv' . $signal->contentId];
     }
 }

--- a/src/SignalSlot/DeleteContentSlot.php
+++ b/src/SignalSlot/DeleteContentSlot.php
@@ -23,7 +23,7 @@ class DeleteContentSlot extends AbstractContentSlot
     {
         $tags = parent::generateTags($signal);
         foreach ($signal->affectedLocationIds as $locationId) {
-            $tags[] = 'path-' . $locationId;
+            $tags[] = 'p' . $locationId;
         }
 
         return $tags;

--- a/src/SignalSlot/DeleteContentSlot.php
+++ b/src/SignalSlot/DeleteContentSlot.php
@@ -24,6 +24,8 @@ class DeleteContentSlot extends AbstractContentSlot
         $tags = parent::generateTags($signal);
         foreach ($signal->affectedLocationIds as $locationId) {
             $tags[] = 'p' . $locationId;
+            // deprecated
+            $tags[] = 'path-' . $locationId;
         }
 
         return $tags;

--- a/src/SignalSlot/DeleteLocationSlot.php
+++ b/src/SignalSlot/DeleteLocationSlot.php
@@ -19,7 +19,7 @@ class DeleteLocationSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'path-' . $signal->locationId;
+        $tags[] = 'p' . $signal->locationId;
 
         return $tags;
     }

--- a/src/SignalSlot/DeleteLocationSlot.php
+++ b/src/SignalSlot/DeleteLocationSlot.php
@@ -20,6 +20,8 @@ class DeleteLocationSlot extends AbstractContentSlot
     {
         $tags = parent::generateTags($signal);
         $tags[] = 'p' . $signal->locationId;
+        // deprecated
+        $tags[] = 'path-' . $signal->locationId;
 
         return $tags;
     }

--- a/src/SignalSlot/DeleteVersionSlot.php
+++ b/src/SignalSlot/DeleteVersionSlot.php
@@ -23,6 +23,6 @@ class DeleteVersionSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-versions-' . $signal->contentId];
+        return ['cv' . $signal->contentId];
     }
 }

--- a/src/SignalSlot/HideLocationSlot.php
+++ b/src/SignalSlot/HideLocationSlot.php
@@ -19,7 +19,7 @@ class HideLocationSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'path-' . $signal->locationId;
+        $tags[] = 'p' . $signal->locationId;
 
         return $tags;
     }

--- a/src/SignalSlot/HideLocationSlot.php
+++ b/src/SignalSlot/HideLocationSlot.php
@@ -20,6 +20,8 @@ class HideLocationSlot extends AbstractContentSlot
     {
         $tags = parent::generateTags($signal);
         $tags[] = 'p' . $signal->locationId;
+        // deprecated
+        $tags[] = 'path-' . $signal->locationId;
 
         return $tags;
     }

--- a/src/SignalSlot/MoveSubtreeSlot.php
+++ b/src/SignalSlot/MoveSubtreeSlot.php
@@ -29,6 +29,13 @@ class MoveSubtreeSlot extends AbstractContentSlot
             'l' . $signal->newParentLocationId,
             // new siblings
             'pl' . $signal->newParentLocationId,
+
+            // deprecated
+            'path-' . $signal->locationId,
+            'location-' . $signal->oldParentLocationId,
+            'parent-' . $signal->oldParentLocationId,
+            'location-' . $signal->newParentLocationId,
+            'parent-' . $signal->newParentLocationId,
         ];
     }
 

--- a/src/SignalSlot/MoveSubtreeSlot.php
+++ b/src/SignalSlot/MoveSubtreeSlot.php
@@ -20,15 +20,15 @@ class MoveSubtreeSlot extends AbstractContentSlot
     {
         return [
             // The tree being moved
-            'path-' . $signal->locationId,
+            'p' . $signal->locationId,
             // old parent
-            'location-' . $signal->oldParentLocationId,
+            'l' . $signal->oldParentLocationId,
             // old siblings
-            'parent-' . $signal->oldParentLocationId,
+            'pl' . $signal->oldParentLocationId,
             // new parent
-            'location-' . $signal->newParentLocationId,
+            'l' . $signal->newParentLocationId,
             // new siblings
-            'parent-' . $signal->newParentLocationId,
+            'pl' . $signal->newParentLocationId,
         ];
     }
 

--- a/src/SignalSlot/RecoverSlot.php
+++ b/src/SignalSlot/RecoverSlot.php
@@ -22,6 +22,10 @@ class RecoverSlot extends AbstractContentSlot
         $tags[] = 'l' . $signal->newParentLocationId;
         $tags[] = 'pl' . $signal->newParentLocationId;
 
+        // deprecated
+        $tags[] = 'location-' . $signal->newParentLocationId;
+        $tags[] = 'parent-' . $signal->newParentLocationId;
+
         return $tags;
     }
 

--- a/src/SignalSlot/RecoverSlot.php
+++ b/src/SignalSlot/RecoverSlot.php
@@ -19,8 +19,8 @@ class RecoverSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'location-' . $signal->newParentLocationId;
-        $tags[] = 'parent-' . $signal->newParentLocationId;
+        $tags[] = 'l' . $signal->newParentLocationId;
+        $tags[] = 'pl' . $signal->newParentLocationId;
 
         return $tags;
     }

--- a/src/SignalSlot/SectionService/DeleteSectionSlot.php
+++ b/src/SignalSlot/SectionService/DeleteSectionSlot.php
@@ -24,6 +24,6 @@ class DeleteSectionSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['section-' . $signal->sectionId];
+        return ['s' . $signal->sectionId];
     }
 }

--- a/src/SignalSlot/SectionService/UpdateSectionSlot.php
+++ b/src/SignalSlot/SectionService/UpdateSectionSlot.php
@@ -24,6 +24,6 @@ class UpdateSectionSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['section-' . $signal->sectionId];
+        return ['s' . $signal->sectionId];
     }
 }

--- a/src/SignalSlot/SwapLocationSlot.php
+++ b/src/SignalSlot/SwapLocationSlot.php
@@ -27,6 +27,16 @@ class SwapLocationSlot extends AbstractContentSlot
             'p' . $signal->location2Id,
             'l' . $signal->parentLocation2Id,
             'pl' . $signal->parentLocation2Id,
+
+            // deprecated
+            'content-' . $signal->content1Id,
+            'path-' . $signal->location1Id,
+            'location-' . $signal->parentLocation1Id,
+            'parent-' . $signal->parentLocation1Id,
+            'content-' . $signal->content2Id,
+            'path-' . $signal->location2Id,
+            'location-' . $signal->parentLocation2Id,
+            'parent-' . $signal->parentLocation2Id,
         ];
     }
 

--- a/src/SignalSlot/SwapLocationSlot.php
+++ b/src/SignalSlot/SwapLocationSlot.php
@@ -19,14 +19,14 @@ class SwapLocationSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         return [
-            'content-' . $signal->content1Id,
-            'path-' . $signal->location1Id,
-            'location-' . $signal->parentLocation1Id,
-            'parent-' . $signal->parentLocation1Id,
-            'content-' . $signal->content2Id,
-            'path-' . $signal->location2Id,
-            'location-' . $signal->parentLocation2Id,
-            'parent-' . $signal->parentLocation2Id,
+            'c' . $signal->content1Id,
+            'p' . $signal->location1Id,
+            'l' . $signal->parentLocation1Id,
+            'pl' . $signal->parentLocation1Id,
+            'c' . $signal->content2Id,
+            'p' . $signal->location2Id,
+            'l' . $signal->parentLocation2Id,
+            'pl' . $signal->parentLocation2Id,
         ];
     }
 

--- a/src/SignalSlot/UnassignUserFromUserGroupSlot.php
+++ b/src/SignalSlot/UnassignUserFromUserGroupSlot.php
@@ -18,7 +18,11 @@ class UnassignUserFromUserGroupSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['c' . $signal->userId, 'c' . $signal->userGroupId, 'ez-user-context-hash'];
+        return [
+            'c' . $signal->userId, 'c' . $signal->userGroupId, 'ez-user-context-hash',
+            // deprecated
+            'content-' . $signal->userId, 'content-' . $signal->userGroupId,
+        ];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/UnassignUserFromUserGroupSlot.php
+++ b/src/SignalSlot/UnassignUserFromUserGroupSlot.php
@@ -18,7 +18,7 @@ class UnassignUserFromUserGroupSlot extends AbstractContentSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId, 'ez-user-context-hash'];
+        return ['c' . $signal->userId, 'c' . $signal->userGroupId, 'ez-user-context-hash'];
     }
 
     protected function supports(Signal $signal)

--- a/src/SignalSlot/UnhideLocationSlot.php
+++ b/src/SignalSlot/UnhideLocationSlot.php
@@ -19,7 +19,7 @@ class UnhideLocationSlot extends AbstractContentSlot
     protected function generateTags(Signal $signal)
     {
         $tags = parent::generateTags($signal);
-        $tags[] = 'path-' . $signal->locationId;
+        $tags[] = 'p' . $signal->locationId;
 
         return $tags;
     }

--- a/src/SignalSlot/UnhideLocationSlot.php
+++ b/src/SignalSlot/UnhideLocationSlot.php
@@ -20,6 +20,8 @@ class UnhideLocationSlot extends AbstractContentSlot
     {
         $tags = parent::generateTags($signal);
         $tags[] = 'p' . $signal->locationId;
+        // deprecated
+        $tags[] = 'path-' . $signal->locationId;
 
         return $tags;
     }

--- a/src/SignalSlot/UpdateContentSlot.php
+++ b/src/SignalSlot/UpdateContentSlot.php
@@ -23,6 +23,6 @@ class UpdateContentSlot extends AbstractSlot
      */
     protected function generateTags(Signal $signal)
     {
-        return ['content-versions-' . $signal->contentId];
+        return ['cv' . $signal->contentId];
     }
 }

--- a/src/SignalSlot/UpdateUrlSlot.php
+++ b/src/SignalSlot/UpdateUrlSlot.php
@@ -38,7 +38,7 @@ class UpdateUrlSlot extends AbstractContentSlot
     {
         if ($signal->urlChanged) {
             return array_map(function ($contentId) {
-                return 'content-' . $contentId;
+                return 'c' . $contentId;
             }, $this->urlHandler->findUsages($signal->urlId));
         }
 

--- a/src/SignalSlot/UpdateUrlSlot.php
+++ b/src/SignalSlot/UpdateUrlSlot.php
@@ -37,7 +37,7 @@ class UpdateUrlSlot extends AbstractContentSlot
     public function generateTags(Signal $signal)
     {
         if ($signal->urlChanged) {
-            return array_map(function ($contentId) {
+            return array_map(static function ($contentId) {
                 return 'c' . $contentId;
             }, $this->urlHandler->findUsages($signal->urlId));
         }

--- a/tests/Proxy/TagAwareStoreTest.php
+++ b/tests/Proxy/TagAwareStoreTest.php
@@ -32,8 +32,15 @@ class TagAwareStoreTest extends TestCase
 
     public function testGetPath()
     {
-        $path = $this->store->getTagPath('location-123') . \DIRECTORY_SEPARATOR . 'en' . sha1('someContent');
-        $this->assertStringStartsWith(__DIR__ . \DIRECTORY_SEPARATOR . 'ez' . \DIRECTORY_SEPARATOR . '32' . \DIRECTORY_SEPARATOR . '1-' . \DIRECTORY_SEPARATOR . 'noitacol', $path);
+        // Test different tag lengths and how it affects paths
+        $path = $this->store->getTagPath('l1');
+        $this->assertEquals(__DIR__ . \DIRECTORY_SEPARATOR . 'ez' . \DIRECTORY_SEPARATOR . '1l', $path);
+
+        $path = $this->store->getTagPath('l123');
+        $this->assertEquals(__DIR__ . \DIRECTORY_SEPARATOR . 'ez' . \DIRECTORY_SEPARATOR . '32' . \DIRECTORY_SEPARATOR . '1l', $path);
+
+        $path = $this->store->getTagPath('0l1234');
+        $this->assertEquals(__DIR__ . \DIRECTORY_SEPARATOR . 'ez' . \DIRECTORY_SEPARATOR . '43' . \DIRECTORY_SEPARATOR . '21' . \DIRECTORY_SEPARATOR . 'l0', $path);
     }
 
     public function testGetStalePath()
@@ -82,7 +89,7 @@ class TagAwareStoreTest extends TestCase
         $fs = $this->getFilesystemMock();
         $this->store->setFilesystem($fs);
         $locationId = 123;
-        $locationCacheDir = $this->store->getTagPath('location-' . $locationId);
+        $locationCacheDir = $this->store->getTagPath('l' . $locationId);
         $staleCacheDir = str_replace(TagAwareStore::TAG_CACHE_DIR, TagAwareStore::TAG_CACHE_DIR, $locationCacheDir);
 
         $fs
@@ -116,7 +123,7 @@ class TagAwareStoreTest extends TestCase
         $locationIds = [123, 456, 789];
         $i = 0;
         foreach ($locationIds as $locationId) {
-            $locationCacheDir = $this->store->getTagPath('location-' . $locationId);
+            $locationCacheDir = $this->store->getTagPath('l' . $locationId);
             $staleCacheDir = str_replace(TagAwareStore::TAG_CACHE_DIR, TagAwareStore::TAG_CACHE_DIR, $locationCacheDir);
 
             $fs

--- a/tests/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/PurgeClient/LocalPurgeClientTest.php
@@ -29,7 +29,7 @@ class LocalPurgeClientTest extends TestCase
     {
         $locationIds = [123, 456, 789];
         $expectedBanRequest = Request::create('http://localhost', 'PURGE');
-        $expectedBanRequest->headers->set('key', 'location-123 location-456 location-789');
+        $expectedBanRequest->headers->set('key', 'l123 l456 l789');
 
         $cacheStore = $this->createMock(RequestAwarePurger::class);
         $cacheStore

--- a/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -49,14 +49,14 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $this->purgeClientMock
             ->expects($this->once())
             ->method('purge')
-            ->with($this->equalTo(['location-123', 'content-44', 'ez-all']));
+            ->with($this->equalTo(['l123', 'c44', 'ez-all']));
 
         $this->tagPrefixMock
             ->expects($this->once())
             ->method('getRepositoryPrefix')
             ->willReturn('');
 
-        $this->prefixDecorator->purge([123, 'content-44', 'ez-all']);
+        $this->prefixDecorator->purge([123, 'c44', 'ez-all']);
     }
 
     public function testPurgeWithPrefix()
@@ -64,14 +64,14 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $this->purgeClientMock
             ->expects($this->once())
             ->method('purge')
-            ->with($this->equalTo(['intranet_location-123', 'intranet_content-44', 'intranet_ez-all']));
+            ->with($this->equalTo(['0l123', '0c44', '0ez-all']));
 
         $this->tagPrefixMock
             ->expects($this->once())
             ->method('getRepositoryPrefix')
-            ->willReturn('intranet_');
+            ->willReturn('0');
 
-        $this->prefixDecorator->purge([123, 'content-44', 'ez-all']);
+        $this->prefixDecorator->purge([123, 'c44', 'ez-all']);
     }
 
     public function testPurgeAll()

--- a/tests/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/PurgeClient/VarnishPurgeClientTest.php
@@ -66,7 +66,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => 'varnishpurgehost']);
+            ->with('/', ['key' => "l$locationId", 'Host' => 'varnishpurgehost']);
 
         $this->configResolver
             ->expects($this->exactly(1))
@@ -92,7 +92,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidatePath')
-            ->with('/', ['key' => "location-$locationId", 'Host' => 'varnishpurgehost', $tokenName => $token]);
+            ->with('/', ['key' => "l$locationId", 'Host' => 'varnishpurgehost', $tokenName => $token]);
 
         $this->configResolver
             ->expects($this->exactly(1))
@@ -133,7 +133,7 @@ class VarnishPurgeClientTest extends TestCase
             ->willReturn(null);
 
         $keys = array_map(static function ($id) {
-            return "location-$id";
+            return "l$id";
         },
             $locationIds
         );
@@ -173,7 +173,7 @@ class VarnishPurgeClientTest extends TestCase
             ->willReturn($token);
 
         $keys = array_map(static function ($id) {
-            return "location-$id";
+            return "l$id";
         },
             $locationIds
         );

--- a/tests/SignalSlot/AbstractContentSlotTest.php
+++ b/tests/SignalSlot/AbstractContentSlotTest.php
@@ -19,23 +19,23 @@ abstract class AbstractContentSlotTest extends AbstractSlotTest
     {
         $tags = [];
         if ($this->contentId) {
-            $tags = ['content-' . $this->contentId, 'relation-' . $this->contentId];
+            $tags = ['c' . $this->contentId, 'r' . $this->contentId];
         }
 
         if ($this->locationId) {
             // self(s)
-            $tags[] = 'location-' . $this->locationId;
+            $tags[] = 'l' . $this->locationId;
             // children
-            $tags[] = 'parent-' . $this->locationId;
+            $tags[] = 'pl' . $this->locationId;
             // reverse location relations
-            $tags[] = 'relation-location-' . $this->locationId;
+            $tags[] = 'rl' . $this->locationId;
         }
 
         if ($this->parentLocationId) {
             // parent(s)
-            $tags[] = 'location-' . $this->parentLocationId;
+            $tags[] = 'l' . $this->parentLocationId;
             // siblings
-            $tags[] = 'parent-' . $this->parentLocationId;
+            $tags[] = 'pl' . $this->parentLocationId;
         }
 
         return $tags;

--- a/tests/SignalSlot/AbstractContentSlotTest.php
+++ b/tests/SignalSlot/AbstractContentSlotTest.php
@@ -19,7 +19,14 @@ abstract class AbstractContentSlotTest extends AbstractSlotTest
     {
         $tags = [];
         if ($this->contentId) {
-            $tags = ['c' . $this->contentId, 'r' . $this->contentId];
+            // self in all forms (also without locations)
+            $tags[] = 'c' . $this->contentId;
+            // reverse relations
+            $tags[] = 'r' . $this->contentId;
+
+            // deprecated
+            $tags[] = 'content-' . $this->contentId;
+            $tags[] = 'relation-' . $this->contentId;
         }
 
         if ($this->locationId) {
@@ -29,6 +36,11 @@ abstract class AbstractContentSlotTest extends AbstractSlotTest
             $tags[] = 'pl' . $this->locationId;
             // reverse location relations
             $tags[] = 'rl' . $this->locationId;
+
+            // deprecated
+            $tags[] = 'location-' . $this->locationId;
+            $tags[] = 'parent-' . $this->locationId;
+            $tags[] = 'relation-location-' . $this->locationId;
         }
 
         if ($this->parentLocationId) {
@@ -36,6 +48,10 @@ abstract class AbstractContentSlotTest extends AbstractSlotTest
             $tags[] = 'l' . $this->parentLocationId;
             // siblings
             $tags[] = 'pl' . $this->parentLocationId;
+
+            // deprecated
+            $tags[] = 'location-' . $this->parentLocationId;
+            $tags[] = 'parent-' . $this->parentLocationId;
         }
 
         return $tags;

--- a/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
+++ b/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
@@ -18,7 +18,7 @@ class AssignUserToUserGroupSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['content-' . $this->contentId, 'content-99', 'ez-user-context-hash'];
+        return ['c' . $this->contentId, 'c99', 'ez-user-context-hash'];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
+++ b/tests/SignalSlot/AssignUserToUserGroupSlotTest.php
@@ -18,7 +18,13 @@ class AssignUserToUserGroupSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['c' . $this->contentId, 'c99', 'ez-user-context-hash'];
+        return [
+            'c' . $this->contentId,
+            'c99',
+            'ez-user-context-hash',
+            'content-' . $this->contentId,
+            'content-99',
+        ];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentService/CreateContentDraftSlotTest.php
+++ b/tests/SignalSlot/ContentService/CreateContentDraftSlotTest.php
@@ -19,7 +19,7 @@ class CreateContentDraftSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-versions-55'];
+        return ['cv55'];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentService/DeleteVersionSlotTest.php
+++ b/tests/SignalSlot/ContentService/DeleteVersionSlotTest.php
@@ -19,7 +19,7 @@ class DeleteVersionSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-versions-55'];
+        return ['cv55'];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentService/UpdateContentSlotTest.php
+++ b/tests/SignalSlot/ContentService/UpdateContentSlotTest.php
@@ -19,7 +19,7 @@ class UpdateContentSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-versions-55'];
+        return ['cv55'];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/ContentTypeService/AssignContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/AssignContentTypeGroupSlotTest.php
@@ -21,7 +21,7 @@ class AssignContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['type-group-4'];
+        return ['tg4'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/DeleteContentTypeGroupSlotTest.php
@@ -21,7 +21,7 @@ class DeleteContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['type-group-4'];
+        return ['tg4'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/DeleteContentTypeSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/DeleteContentTypeSlotTest.php
@@ -21,7 +21,7 @@ class DeleteContentTypeSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-type-4', 'type-4'];
+        return ['ct4', 't4'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/PublishContentTypeSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/PublishContentTypeSlotTest.php
@@ -21,7 +21,7 @@ class PublishContentTypeSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['content-type-4', 'type-4'];
+        return ['ct4', 't4'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/UnassignContentTypeGroupSlotTest.php
@@ -21,7 +21,7 @@ class UnassignContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['type-group-4'];
+        return ['tg4'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlotTest.php
+++ b/tests/SignalSlot/ContentTypeService/UpdateContentTypeGroupSlotTest.php
@@ -21,7 +21,7 @@ class UpdateContentTypeGroupSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['type-group-4'];
+        return ['tg4'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/CopyContentSlotTest.php
+++ b/tests/SignalSlot/CopyContentSlotTest.php
@@ -19,7 +19,15 @@ class CopyContentSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['c' . $this->contentId, 'l' . $this->parentLocationId, 'p' . $this->parentLocationId];
+        return [
+            'c' . $this->contentId,
+            'l' . $this->parentLocationId,
+            'p' . $this->parentLocationId,
+
+            'content-' . $this->contentId,
+            'location-' . $this->parentLocationId,
+            'path-' . $this->parentLocationId,
+        ];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/CopyContentSlotTest.php
+++ b/tests/SignalSlot/CopyContentSlotTest.php
@@ -19,7 +19,7 @@ class CopyContentSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['content-' . $this->contentId, 'location-' . $this->parentLocationId, 'path-' . $this->parentLocationId];
+        return ['c' . $this->contentId, 'l' . $this->parentLocationId, 'p' . $this->parentLocationId];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/CopySubtreeSlotTest.php
+++ b/tests/SignalSlot/CopySubtreeSlotTest.php
@@ -27,8 +27,8 @@ class CopySubtreeSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         return [
-            'location-' . $this->targetParentLocationId,
-            'parent-' . $this->targetParentLocationId,
+            'l' . $this->targetParentLocationId,
+            'pl' . $this->targetParentLocationId,
         ];
     }
 

--- a/tests/SignalSlot/CopySubtreeSlotTest.php
+++ b/tests/SignalSlot/CopySubtreeSlotTest.php
@@ -29,6 +29,8 @@ class CopySubtreeSlotTest extends AbstractContentSlotTest
         return [
             'l' . $this->targetParentLocationId,
             'pl' . $this->targetParentLocationId,
+            'location-' . $this->targetParentLocationId,
+            'parent-' . $this->targetParentLocationId,
         ];
     }
 

--- a/tests/SignalSlot/DeleteContentSlotTest.php
+++ b/tests/SignalSlot/DeleteContentSlotTest.php
@@ -18,8 +18,8 @@ class DeleteContentSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
-        $tags[] = 'path-45';
-        $tags[] = 'path-55';
+        $tags[] = 'p45';
+        $tags[] = 'p55';
 
         return $tags;
     }

--- a/tests/SignalSlot/DeleteContentSlotTest.php
+++ b/tests/SignalSlot/DeleteContentSlotTest.php
@@ -19,7 +19,9 @@ class DeleteContentSlotTest extends AbstractContentSlotTest
     {
         $tags = parent::generateTags();
         $tags[] = 'p45';
+        $tags[] = 'path-45';
         $tags[] = 'p55';
+        $tags[] = 'path-55';
 
         return $tags;
     }

--- a/tests/SignalSlot/DeleteLocationSlotTest.php
+++ b/tests/SignalSlot/DeleteLocationSlotTest.php
@@ -28,6 +28,7 @@ class DeleteLocationSlotTest extends AbstractContentSlotTest
     {
         $tags = parent::generateTags();
         $tags[] = 'p' . $this->locationId;
+        $tags[] = 'path-' . $this->locationId;
 
         return $tags;
     }

--- a/tests/SignalSlot/DeleteLocationSlotTest.php
+++ b/tests/SignalSlot/DeleteLocationSlotTest.php
@@ -27,7 +27,7 @@ class DeleteLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
-        $tags[] = 'path-' . $this->locationId;
+        $tags[] = 'p' . $this->locationId;
 
         return $tags;
     }

--- a/tests/SignalSlot/HideLocationSlotTest.php
+++ b/tests/SignalSlot/HideLocationSlotTest.php
@@ -26,6 +26,7 @@ class HideLocationSlotTest extends AbstractContentSlotTest
     {
         $tags = parent::generateTags();
         $tags[] = 'p' . $this->locationId;
+        $tags[] = 'path-' . $this->locationId;
 
         return $tags;
     }

--- a/tests/SignalSlot/HideLocationSlotTest.php
+++ b/tests/SignalSlot/HideLocationSlotTest.php
@@ -25,7 +25,7 @@ class HideLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
-        $tags[] = 'path-' . $this->locationId;
+        $tags[] = 'p' . $this->locationId;
 
         return $tags;
     }

--- a/tests/SignalSlot/MoveSubtreeSlotTest.php
+++ b/tests/SignalSlot/MoveSubtreeSlotTest.php
@@ -27,7 +27,19 @@ class MoveSubtreeSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['p' . $this->locationId, 'l' . $this->oldParentLocationId, 'pl' . $this->oldParentLocationId, 'l' . $this->parentLocationId, 'pl' . $this->parentLocationId];
+        return [
+            'p' . $this->locationId,
+            'l' . $this->oldParentLocationId,
+            'pl' . $this->oldParentLocationId,
+            'l' . $this->parentLocationId,
+            'pl' . $this->parentLocationId,
+
+            'path-' . $this->locationId,
+            'location-' . $this->oldParentLocationId,
+            'parent-' . $this->oldParentLocationId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
+        ];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/MoveSubtreeSlotTest.php
+++ b/tests/SignalSlot/MoveSubtreeSlotTest.php
@@ -27,7 +27,7 @@ class MoveSubtreeSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['path-' . $this->locationId, 'location-' . $this->oldParentLocationId, 'parent-' . $this->oldParentLocationId, 'location-' . $this->parentLocationId, 'parent-' . $this->parentLocationId];
+        return ['p' . $this->locationId, 'l' . $this->oldParentLocationId, 'pl' . $this->oldParentLocationId, 'l' . $this->parentLocationId, 'pl' . $this->parentLocationId];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/RecoverSlotTest.php
+++ b/tests/SignalSlot/RecoverSlotTest.php
@@ -29,8 +29,12 @@ class RecoverSlotTest extends AbstractContentSlotTest
         return [
             'c' . $this->contentId,
             'r' . $this->contentId,
+            'content-' . $this->contentId,
+            'relation-' . $this->contentId,
             'l' . $this->parentLocationId,
             'pl' . $this->parentLocationId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
         ];
     }
 

--- a/tests/SignalSlot/RecoverSlotTest.php
+++ b/tests/SignalSlot/RecoverSlotTest.php
@@ -27,10 +27,10 @@ class RecoverSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         return [
-            'content-' . $this->contentId,
-            'relation-' . $this->contentId,
-            'location-' . $this->parentLocationId,
-            'parent-' . $this->parentLocationId,
+            'c' . $this->contentId,
+            'r' . $this->contentId,
+            'l' . $this->parentLocationId,
+            'pl' . $this->parentLocationId,
         ];
     }
 

--- a/tests/SignalSlot/SectionService/DeleteSectionSlotTest.php
+++ b/tests/SignalSlot/SectionService/DeleteSectionSlotTest.php
@@ -21,7 +21,7 @@ class DeleteSectionSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['section-2'];
+        return ['s2'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/SectionService/UpdateSectionSlotTest.php
+++ b/tests/SignalSlot/SectionService/UpdateSectionSlotTest.php
@@ -21,7 +21,7 @@ class UpdateSectionSlotTest extends AbstractSlotTest
 
     public function generateTags()
     {
-        return ['section-2'];
+        return ['s2'];
     }
 
     public function getReceivedSignalClasses()

--- a/tests/SignalSlot/SwapLocationSlotTest.php
+++ b/tests/SignalSlot/SwapLocationSlotTest.php
@@ -32,14 +32,14 @@ class SwapLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         return [
-            'content-' . $this->contentId,
-            'path-' . $this->locationId,
-            'location-' . $this->parentLocationId,
-            'parent-' . $this->parentLocationId,
-            'content-' . $this->swapContentId,
-            'path-' . $this->swapLocationId,
-            'location-' . $this->swapParentLocationId,
-            'parent-' . $this->swapParentLocationId,
+            'c' . $this->contentId,
+            'p' . $this->locationId,
+            'l' . $this->parentLocationId,
+            'pl' . $this->parentLocationId,
+            'c' . $this->swapContentId,
+            'p' . $this->swapLocationId,
+            'l' . $this->swapParentLocationId,
+            'pl' . $this->swapParentLocationId,
         ];
     }
 

--- a/tests/SignalSlot/SwapLocationSlotTest.php
+++ b/tests/SignalSlot/SwapLocationSlotTest.php
@@ -40,6 +40,16 @@ class SwapLocationSlotTest extends AbstractContentSlotTest
             'p' . $this->swapLocationId,
             'l' . $this->swapParentLocationId,
             'pl' . $this->swapParentLocationId,
+
+            // deprecated
+            'content-' . $this->contentId,
+            'path-' . $this->locationId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
+            'content-' . $this->swapContentId,
+            'path-' . $this->swapLocationId,
+            'location-' . $this->swapParentLocationId,
+            'parent-' . $this->swapParentLocationId,
         ];
     }
 

--- a/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
+++ b/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
@@ -18,7 +18,7 @@ class UnassignUserFromUserGroupSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['content-' . $this->contentId, 'content-99', 'ez-user-context-hash'];
+        return ['c' . $this->contentId, 'c99', 'ez-user-context-hash'];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
+++ b/tests/SignalSlot/UnassignUserFromUserGroupSlotTest.php
@@ -18,7 +18,13 @@ class UnassignUserFromUserGroupSlotTest extends AbstractContentSlotTest
 
     public function generateTags()
     {
-        return ['c' . $this->contentId, 'c99', 'ez-user-context-hash'];
+        return [
+            'c' . $this->contentId,
+            'c99',
+            'ez-user-context-hash',
+            'content-' . $this->contentId,
+            'content-99',
+        ];
     }
 
     public function getSlotClass()

--- a/tests/SignalSlot/UnhideLocationSlotTest.php
+++ b/tests/SignalSlot/UnhideLocationSlotTest.php
@@ -26,6 +26,8 @@ class UnhideLocationSlotTest extends AbstractContentSlotTest
     {
         $tags = parent::generateTags();
         $tags[] = 'p' . $this->locationId;
+        // deprecated
+        $tags[] = 'path-' . $this->locationId;
 
         return $tags;
     }

--- a/tests/SignalSlot/UnhideLocationSlotTest.php
+++ b/tests/SignalSlot/UnhideLocationSlotTest.php
@@ -25,7 +25,7 @@ class UnhideLocationSlotTest extends AbstractContentSlotTest
     public function generateTags()
     {
         $tags = parent::generateTags();
-        $tags[] = 'path-' . $this->locationId;
+        $tags[] = 'p' . $this->locationId;
 
         return $tags;
     }

--- a/tests/SignalSlot/UpdateUrlSlotTest.php
+++ b/tests/SignalSlot/UpdateUrlSlotTest.php
@@ -57,7 +57,7 @@ class UpdateUrlSlotTest extends AbstractSlotTest
     public function generateTags()
     {
         return array_map(function ($id) {
-            return 'content-' . $id;
+            return 'c' . $id;
         }, self::CONTENT_IDS);
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30562](https://jira.ez.no/browse/EZP-30562)
| **Type**           | Improvement/Feature/Bug
| **Target version** | new `1.0` branch for LTS releases, implies master should become `2.0`
| **BC breaks**      | yes
| **Doc needed**     | yes

#### Why

> Servers like Apache or nginx have a limit of a response header size. In some cases, for instance, when RichText contains a lot of embedded images, HTTP tags header (x-key) might be too long. It might cause 500 error in case of environment based on Apache + PHP-FPM. To ~avoid~ reduce such a situation tags should be shortened.

#### What
_Builds on what @kmadejski proposed in #86 after discussions in PS recently._

Reduces tags from i.e. `intranet_content-22` to `1c22`, compared to recent proposal to hash tags this:
- Is mostly shorter _(with hash it would always be 8 characters)_
- More readable, and does not differ between `dev` & `prod`

BC is kept on purges in content slots for this branch, so templates/php code using documented tags already won't stop working, but this is done as own commit so it can be reverted for v3 branch.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- **Doc**: Update doc.ezplatform.com once this is accepted and switched to in meta branch
- **DO NOT MERGE THIS**: Once approved and cleaned up just close PR and let branch stays as is, merge to master and bump master to 2.x.
