### PR TITLE
EZP-31359: Common content http cache tag abstractions

### DIFF
--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -47,21 +47,21 @@ Varnish or Fastly are highly recommended for medium to large traffic needs. Besi
    _For use when updates affect all their reverse relations. ezplatform-http-cache does not add this tag to responses
    automatically, just purges on it if present, response tagging with this is currently done inline in template logic / views
    where relation is actually used for rendering (when using ESI, if inline it's own tags will be added to response).
-   ezpublish-kernel add these as of v6.13.2/v7.1.0 on default relation templates)_
+   These differs from `content-` and `location-` by _only_ being purged when relation itself is removed or otherwise affected._
 
 ### Tags for Section responses
 
 - `section-<section-id>` :
-  _For use when section changes affecting section reponses (i.e. REST)._
+  _For use when section changes affecting section responses (i.e. REST)._
 
 
 ### Tags for ContenType responses
 
 - `type-<content-type-id>` :
-  _For use when content type changes affecting content type reponses (i.e. REST)._
+  _For use when content type changes affecting content type responses (i.e. REST)._
 
 - `type-group-<content-type-id>` :
-  _For use when content type group changes affecting content type group reponses (i.e. REST)._
+  _For use when content type group changes affecting content type group responses (i.e. REST)._
 
 ### Misc
 

--- a/src/Handler/ContentTagInterface.php
+++ b/src/Handler/ContentTagInterface.php
@@ -11,6 +11,14 @@ namespace EzSystems\PlatformHttpCacheBundle\Handler;
  */
 interface ContentTagInterface
 {
+    const CONTENT_PREFIX = 'content-';
+    const LOCATION_PREFIX = 'location-';
+    const PARENT_LOCATION_PREFIX = 'parent-';
+    const PATH_PREFIX = 'path-';
+    const RELATION_PREFIX = 'relation-';
+    const RELATION_LOCATION_PREFIX = 'relation-location-';
+    const CONTENT_TYPE_PREFIX = 'content-type-';
+
     /**
      * Low level tag method to add content tag.
      *
@@ -26,6 +34,14 @@ interface ContentTagInterface
      * @param array $locationIds
      */
     public function addLocationTags(array $locationIds);
+
+    /**
+     * Low level tag method to add parent location tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $parentLocationIds
+     */
+    public function addParentLocationTags(array $parentLocationIds);
 
     /**
      * Low level tag method to add location path tag.
@@ -50,4 +66,12 @@ interface ContentTagInterface
      * @param array $locationIds
      */
     public function addRelationLocationTags(array $locationIds);
+
+    /**
+     * Low level tag method to add relation location tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $contentTypeIds
+     */
+    public function addContentTypeTags(array $contentTypeIds);
 }

--- a/src/Handler/ContentTagInterface.php
+++ b/src/Handler/ContentTagInterface.php
@@ -23,6 +23,7 @@ interface ContentTagInterface
      * Low level tag method to add content tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $contentIds
      */
     public function addContentTags(array $contentIds);
@@ -31,6 +32,7 @@ interface ContentTagInterface
      * Low level tag method to add location tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $locationIds
      */
     public function addLocationTags(array $locationIds);
@@ -39,6 +41,7 @@ interface ContentTagInterface
      * Low level tag method to add parent location tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $parentLocationIds
      */
     public function addParentLocationTags(array $parentLocationIds);
@@ -47,6 +50,7 @@ interface ContentTagInterface
      * Low level tag method to add location path tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $locationIds
      */
     public function addPathTags(array $locationIds);
@@ -55,6 +59,7 @@ interface ContentTagInterface
      * Low level tag method to add relation tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $contentIds
      */
     public function addRelationTags(array $contentIds);
@@ -63,6 +68,7 @@ interface ContentTagInterface
      * Low level tag method to add relation location tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $locationIds
      */
     public function addRelationLocationTags(array $locationIds);
@@ -71,6 +77,7 @@ interface ContentTagInterface
      * Low level tag method to add relation location tag.
      *
      * @see "docs/using_tags.md"
+     *
      * @param array $contentTypeIds
      */
     public function addContentTypeTags(array $contentTypeIds);

--- a/src/Handler/ContentTagInterface.php
+++ b/src/Handler/ContentTagInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformHttpCacheBundle\Handler;
+
+/**
+ * @since v0.9.3
+ */
+interface ContentTagInterface
+{
+    /**
+     * Low level tag method to add content tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $contentIds
+     */
+    public function addContentTags(array $contentIds);
+
+    /**
+     * Low level tag method to add location tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $locationIds
+     */
+    public function addLocationTags(array $locationIds);
+
+    /**
+     * Low level tag method to add location path tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $locationIds
+     */
+    public function addPathTags(array $locationIds);
+
+    /**
+     * Low level tag method to add relation tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $contentIds
+     */
+    public function addRelationTags(array $contentIds);
+
+    /**
+     * Low level tag method to add relation location tag.
+     *
+     * @see "docs/using_tags.md"
+     * @param array $locationIds
+     */
+    public function addRelationLocationTags(array $locationIds);
+}

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -87,7 +87,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addContentTags(array $contentIds)
     {
@@ -97,7 +97,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addLocationTags(array $locationIds)
     {
@@ -107,7 +107,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addParentLocationTags(array $parentLocationIds)
     {
@@ -117,17 +117,17 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addPathTags(array $locationIds)
     {
         $this->addTags(array_map(static function ($locationId) {
-            return ContentTagInterface::PATH_PREFIX  . $locationId;
+            return ContentTagInterface::PATH_PREFIX . $locationId;
         }, $locationIds));
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addRelationTags(array $contentIds)
     {
@@ -137,7 +137,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addRelationLocationTags(array $locationIds)
     {
@@ -147,7 +147,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function addContentTypeTags(array $contentTypeIds)
     {

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -18,7 +18,7 @@ use FOS\HttpCacheBundle\CacheManager;
  * php app/console fos:httpcache:invalidate:tag <tag>.
  *
  * It implements tagResponse() to make sure TagSubscriber (a FOS event listener) sends tags using the header
- * we have configured, and to be able to prefix tags with respository id in order to support multi repo setups.
+ * we have configured, and to be able to prefix tags with repository id in order to support multi repo setups.
  */
 class TagHandler extends FOSTagHandler implements ContentTagInterface
 {
@@ -92,7 +92,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     public function addContentTags(array $contentIds)
     {
         $this->addTags(array_map(static function ($contentId) {
-            return 'content-' . $contentId;
+            return ContentTagInterface::CONTENT_PREFIX . $contentId;
         }, $contentIds));
     }
 
@@ -102,8 +102,18 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     public function addLocationTags(array $locationIds)
     {
         $this->addTags(array_map(static function ($locationId) {
-            return 'location-' . $locationId;
+            return ContentTagInterface::LOCATION_PREFIX . $locationId;
         }, $locationIds));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addParentLocationTags(array $parentLocationIds)
+    {
+        $this->addTags(array_map(static function ($parentLocationId) {
+            return ContentTagInterface::PARENT_LOCATION_PREFIX . $parentLocationId;
+        }, $parentLocationIds));
     }
 
     /**
@@ -112,7 +122,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     public function addPathTags(array $locationIds)
     {
         $this->addTags(array_map(static function ($locationId) {
-            return 'path-' . $locationId;
+            return ContentTagInterface::PATH_PREFIX  . $locationId;
         }, $locationIds));
     }
 
@@ -122,7 +132,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     public function addRelationTags(array $contentIds)
     {
         $this->addTags(array_map(static function ($contentId) {
-            return 'relation-' . $contentId;
+            return ContentTagInterface::RELATION_PREFIX . $contentId;
         }, $contentIds));
     }
 
@@ -132,7 +142,17 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     public function addRelationLocationTags(array $locationIds)
     {
         $this->addTags(array_map(static function ($locationId) {
-            return 'relation-location-' . $locationId;
+            return ContentTagInterface::RELATION_LOCATION_PREFIX . $locationId;
         }, $locationIds));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addContentTypeTags(array $contentTypeIds)
+    {
+        $this->addTags(array_map(static function ($contentTypeId) {
+            return ContentTagInterface::CONTENT_TYPE_PREFIX . $contentTypeId;
+        }, $contentTypeIds));
     }
 }

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -20,7 +20,7 @@ use FOS\HttpCacheBundle\CacheManager;
  * It implements tagResponse() to make sure TagSubscriber (a FOS event listener) sends tags using the header
  * we have configured, and to be able to prefix tags with respository id in order to support multi repo setups.
  */
-class TagHandler extends FOSTagHandler
+class TagHandler extends FOSTagHandler implements ContentTagInterface
 {
     private $cacheManager;
     private $purgeClient;
@@ -84,5 +84,55 @@ class TagHandler extends FOSTagHandler
         }
 
         return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addContentTags(array $contentIds)
+    {
+        $this->addTags(array_map(static function ($contentId) {
+            return 'content-' . $contentId;
+        }, $contentIds));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addLocationTags(array $locationIds)
+    {
+        $this->addTags(array_map(static function ($locationId) {
+            return 'location-' . $locationId;
+        }, $locationIds));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addPathTags(array $locationIds)
+    {
+        $this->addTags(array_map(static function ($locationId) {
+            return 'path-' . $locationId;
+        }, $locationIds));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addRelationTags(array $contentIds)
+    {
+        $this->addTags(array_map(static function ($contentId) {
+            return 'relation-' . $contentId;
+        }, $contentIds));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addRelationLocationTags(array $locationIds)
+    {
+        $this->addTags(array_map(static function ($locationId) {
+            return 'relation-location-' . $locationId;
+        }, $locationIds));
     }
 }

--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -81,6 +81,8 @@ services:
     # Twig
     ezplatform.view_cache.twig_extension:
         class: EzSystems\PlatformHttpCacheBundle\Twig\ContentTaggingExtension
-        arguments: ['@ezplatform.view_cache.response_tagger.dispatcher']
+        arguments:
+            - '@ezplatform.view_cache.response_tagger.dispatcher'
+            - '@fos_http_cache.handler.tag_handler'
         tags:
             - {name: twig.extension}

--- a/src/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/ResponseTagger/Value/ContentInfoTagger.php
@@ -19,7 +19,7 @@ class ContentInfoTagger extends AbstractValueTagger
 
         $this->tagHandler->addTags([
             ContentTagInterface::CONTENT_PREFIX . $value->id,
-            ContentTagInterface::CONTENT_TYPE_PREFIX . $value->contentTypeId
+            ContentTagInterface::CONTENT_TYPE_PREFIX . $value->contentTypeId,
         ]);
 
         if ($value->mainLocationId) {

--- a/src/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/ResponseTagger/Value/ContentInfoTagger.php
@@ -7,6 +7,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\PlatformHttpCacheBundle\Handler\ContentTagInterface;
 
 class ContentInfoTagger extends AbstractValueTagger
 {
@@ -16,10 +17,13 @@ class ContentInfoTagger extends AbstractValueTagger
             return $this;
         }
 
-        $this->tagHandler->addTags(['content-' . $value->id, 'content-type-' . $value->contentTypeId]);
+        $this->tagHandler->addTags([
+            ContentTagInterface::CONTENT_PREFIX . $value->id,
+            ContentTagInterface::CONTENT_TYPE_PREFIX . $value->contentTypeId
+        ]);
 
         if ($value->mainLocationId) {
-            $this->tagHandler->addTags(['location-' . $value->mainLocationId]);
+            $this->tagHandler->addTags([ContentTagInterface::LOCATION_PREFIX . $value->mainLocationId]);
         }
     }
 }

--- a/src/ResponseTagger/Value/LocationTagger.php
+++ b/src/ResponseTagger/Value/LocationTagger.php
@@ -7,6 +7,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\PlatformHttpCacheBundle\Handler\ContentTagInterface;
 
 class LocationTagger extends AbstractValueTagger
 {
@@ -17,14 +18,14 @@ class LocationTagger extends AbstractValueTagger
         }
 
         if ($value->id !== $value->contentInfo->mainLocationId) {
-            $this->tagHandler->addTags(['location-' . $value->id]);
+            $this->tagHandler->addTags([ContentTagInterface::LOCATION_PREFIX . $value->id]);
         }
 
-        $this->tagHandler->addTags(['parent-' . $value->parentLocationId]);
+        $this->tagHandler->addTags([ContentTagInterface::PARENT_LOCATION_PREFIX . $value->parentLocationId]);
         $this->tagHandler->addTags(
             array_map(
-                function ($pathItem) {
-                    return 'path-' . $pathItem;
+                static function ($pathItem) {
+                    return ContentTagInterface::PATH_PREFIX . $pathItem;
                 },
                 $value->path
             )

--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\PlatformHttpCacheBundle\Twig;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
 use Twig_Extension;

--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -8,6 +8,7 @@ namespace EzSystems\PlatformHttpCacheBundle\Twig;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\PlatformHttpCacheBundle\Handler\ContentTagInterface;
 use EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger;
 use Twig_Extension;
 use Twig_SimpleFunction;
@@ -21,9 +22,13 @@ class ContentTaggingExtension extends Twig_Extension
     /** @var \EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger */
     protected $responseTagger;
 
-    public function __construct(ResponseTagger $responseTagger)
+    /** @var \EzSystems\PlatformHttpCacheBundle\Handler\ContentTagInterface */
+    protected $contentTagHandler;
+
+    public function __construct(ResponseTagger $responseTagger, ContentTagInterface $contentTagHandler)
     {
         $this->responseTagger = $responseTagger;
+        $this->contentTagHandler = $contentTagHandler;
     }
 
     /**
@@ -36,11 +41,19 @@ class ContentTaggingExtension extends Twig_Extension
                 'ez_http_tag_location',
                 [$this, 'tagHttpCacheForLocation']
             ),
+            new Twig_SimpleFunction(
+                'ez_http_tag_relation_ids',
+                [$this, 'tagHttpCacheForRelationIds']
+            ),
+            new Twig_SimpleFunction(
+                'ez_http_tag_relation_location_ids',
+                [$this, 'tagHttpCacheForRelationLocationIds']
+            ),
         ];
     }
 
     /**
-     * Adds tags to current response.
+     * Adds tags to current response, for all tags relevant for the location object.
      *
      * @internal Function is only for use within this class (and implicit by Twig).
      *
@@ -50,5 +63,29 @@ class ContentTaggingExtension extends Twig_Extension
     {
         $this->responseTagger->tag($location);
         $this->responseTagger->tag($location->getContentInfo());
+    }
+
+    /**
+     * Adds tags to current response, for relations only.
+     *
+     * @internal Function is only for use within this class (and implicit by Twig).
+     *
+     * @param int|int[] $contentIds
+     */
+    public function tagHttpCacheForRelationIds($contentIds)
+    {
+        $this->contentTagHandler->addRelationTags((array)$contentIds);
+    }
+
+    /**
+     * Adds tags to current response, for relations locations only.
+     *
+     * @internal Function is only for use within this class (and implicit by Twig).
+     *
+     * @param int|int[] $locationIds
+     */
+    public function tagHttpCacheForRelationLocationIds($locationIds)
+    {
+        $this->contentTagHandler->addRelationLocationTags((array)$locationIds);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31359](https://jira.ez.no/browse/EZP-31359)
| **Type**           | Bug/Improvement
| **Target version** | `0.9` In order to provide future compatibility for page builder and others
| **BC breaks**      | no
| **Doc needed**     | yes, but better if this is done together with the other changes done in 1.0

Exposes abstractions and constants for the content tag prefixes which are the once documented to be used externally.

_NB: I on purpose did not use the new constant in Slots here, I'll adapt 1.0 and the corresponding master branch for that instead, less conflicts._

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
