### PR TITLE
EZP-30562: Make it possible to ignore tags over configurable max length

### DIFF
--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -248,7 +248,7 @@ However if for instance you just display the content name, image attribute, and/
 - Optionally: Set reduced cache TTL for the given view in order to reduce remote risk of subtree operations affecting the cached page
   without correctly purging the view.
 
-If that is not an option, you can opt-in to set a  max length parameter (in bytes) and corresponding ttl (seconds)
+If that is not an option, you can opt-in to set a max length parameter (in bytes) and corresponding ttl (in seconds):
 ```yaml
 parameters:
     # Warning, setting this means you risk losing tag information, risking stale cache. Here set below 8k:

--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -238,12 +238,21 @@ code involved to see if amount of tags can be reduced.
 
 #### Limit tags header output by system
 
-Typical case with too many tags would be when inline rendering some form of embed content object.
+Typical case with too many tags would be when inline rendering a lot of embed content object.
 Normally the system will add all the tags for this content, to handle every possible scenario of updates to them.
 
-So if you embed hundreds of content on the same page _(in richtext, using relations, or using page builder)_, it will explode the tag usage.
+So if you embed hundreds of content on the same page _(i.e. in richtext, using relations, or using page builder)_, it will explode the tag usage.
 
 However if for instance you just display the content name, image attribute, and/or link, then it would be enough to:
 - Just use `r<id>` tag, or preferably the abstractions for it.
 - Optionally: Set reduced cache TTL for the given view in order to reduce remote risk of subtree operations affecting the cached page
   without correctly purging the view.
+
+If that is not an option, you can opt-in to set a  max length parameter (in bytes) and corresponding ttl (seconds)
+```yaml
+parameters:
+    # Warning, setting this means you risk losing tag information, risking stale cache. Here set below 8k:
+    ezplatform.http_cache.tags.header_max_length: 7900
+    # In order to reduce risk of stale cache issues, you should set a lower TTL here then globally (here set as 2h)
+    ezplatform.http_cache.tags.header_reduced_ttl: 7200
+```

--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -26,7 +26,7 @@ class TagHandlerSpec extends ObjectBehavior
         $response->headers = $responseHeaderBag;
         $cacheManager->supports(CacheManager::INVALIDATE)->willReturn(true);
 
-        $this->beConstructedWith($cacheManager, 'xkey', $purgeClient, $tagPrefix);
+        $this->beConstructedWith($cacheManager, 'xkey', $purgeClient, $tagPrefix, 1000);
     }
 
     public function it_calls_purge_on_invalidate()
@@ -115,5 +115,25 @@ class TagHandlerSpec extends ObjectBehavior
         $this->addTags(['l4', 'c4']);
         $this->addTags(['p2']);
         $this->tagResponse($response, false);
+    }
+
+    public function it_ignores_too_long_tag_header(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix)
+    {
+        $underLimitTags = 'ez-all';
+        $length = 6;
+        while(true) {
+            $tag = ' content-' . $length;
+            $tagLength = strlen($tag);
+            if ($length + $tagLength  > 1000) {
+                break; // too long if we add more
+            }
+            $underLimitTags .= $tag;
+            $length += $tagLength;
+        }
+        $responseHeaderBag->set('xkey', Argument::exact($underLimitTags))->shouldBeCalled();
+
+        $this->addTags(explode(' ', $underLimitTags));
+        $this->addTags(['location-1111111', 'content-1111111']); // these tags are ignored
+        $this->tagResponse($response, true);
     }
 }

--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -29,6 +29,8 @@ class TagHandlerSpec extends ObjectBehavior
         $cacheManager->supports(CacheManager::INVALIDATE)->willReturn(true);
 
         $this->beConstructedWith($cacheManager, 'xkey', $purgeClient, $tagPrefix, $logger, 1000, 300);
+
+        $tagPrefix->getRepositoryPrefix()->willReturn('');
     }
 
     public function it_calls_purge_on_invalidate()
@@ -100,7 +102,7 @@ class TagHandlerSpec extends ObjectBehavior
     public function it_tags_all_tags_we_add_and_prefix_with_repo_id(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix)
     {
         $tagPrefix->getRepositoryPrefix()->willReturn('0');
-        $responseHeaderBag->set('xkey', Argument::exact('0ez-all 0l4 0c4 0p2 ez-all'))->shouldBeCalled();
+        $responseHeaderBag->set('xkey', Argument::exact('ez-all 0ez-all 0l4 0c4 0p2'))->shouldBeCalled();
 
         $this->addTags(['l4', 'c4']);
         $this->addTags(['p2']);
@@ -112,7 +114,7 @@ class TagHandlerSpec extends ObjectBehavior
         $tagPrefix->getRepositoryPrefix()->willReturn('2');
         $responseHeaderBag->has('xkey')->willReturn(true);
         $responseHeaderBag->get('xkey', null, false)->willReturn(['tag1']);
-        $responseHeaderBag->set('xkey', Argument::exact('2tag1 2ez-all 2l4 2c4 2p2 ez-all'))->shouldBeCalled();
+        $responseHeaderBag->set('xkey', Argument::exact('ez-all 2tag1 2ez-all 2l4 2c4 2p2'))->shouldBeCalled();
 
         $this->addTags(['l4', 'c4']);
         $this->addTags(['p2']);

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -26,10 +26,13 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     private $purgeClient;
     private $prefixService;
     private $tagsHeader;
+
     /** @var \Psr\Log\LoggerInterface */
     private $logger;
+
     /** @var int|null */
     private $tagsHeaderMaxLength;
+
     /** @var int|null */
     private $tagsHeaderReducedTTl;
 

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -26,7 +26,7 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     private $purgeClient;
     private $prefixService;
     private $tagsHeader;
-    /** @var LoggerInterface */
+    /** @var \Psr\Log\LoggerInterface */
     private $logger;
     /** @var int|null */
     private $tagsHeaderMaxLength;
@@ -102,8 +102,10 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
                 $tags
             );
 
-            // Also add a un-prefixed `ez-all` in order to be able to purge all across repos
-            $tags[] = 'ez-all';
+            if ($repoPrefix !== '') {
+                // An un-prefixed `ez-all` for purging across repos, add to start of array to avoid being truncated
+                array_unshift($tags, 'ez-all');
+            }
 
             $tagsString = implode(' ', array_unique($tags));
             $tagsLength = strlen($tagsString);

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -26,12 +26,12 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
     private $purgeClient;
     private $prefixService;
     private $tagsHeader;
+    /** @var LoggerInterface */
+    private $logger;
     /** @var int|null */
     private $tagsHeaderMaxLength;
     /** @var int|null */
     private $tagsHeaderReducedTTl;
-    /** @var LoggerInterface */
-    private $logger;
 
     public function __construct(
         CacheManager $cacheManager,
@@ -106,10 +106,14 @@ class TagHandler extends FOSTagHandler implements ContentTagInterface
             $tags[] = 'ez-all';
 
             $tagsString = implode(' ', array_unique($tags));
-            if ($this->tagsHeaderMaxLength && strlen($tagsString) > $this->tagsHeaderMaxLength) {
-                $tagsString = trim(substr($tagsString, 0, strrpos(
-                    substr($tagsString, 0, $this->tagsHeaderMaxLength + 1), ' '
-                )));
+            $tagsLength = strlen($tagsString);
+            if ($this->tagsHeaderMaxLength && $tagsLength > $this->tagsHeaderMaxLength) {
+                $tagsString = substr(
+                    $tagsString,
+                    0,
+                    // Seek backwards from point of max length using negative offset
+                    strrpos($tagsString, ' ', $this->tagsHeaderMaxLength - $tagsLength)
+                );
 
                 $responseSharedMaxAge = $response->headers->getCacheControlDirective('s-maxage');
                 if (

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,7 @@ parameters:
     ezplatform.http_cache.controller.invalidatetoken.class: EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController
     ezplatform.http_cache.listener.vary_header.class: EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener
     ezplatform.http_cache.tags.header_max_length: null
+    ezplatform.http_cache.tags.header_reduced_ttl: null
 
 services:
     ezplatform.http_cache.cache_manager:
@@ -53,6 +54,7 @@ services:
          - '@ezplatform.http_cache.repository_tag_prefix'
          - '@logger'
          - '%ezplatform.http_cache.tags.header_max_length%'
+         - '%ezplatform.http_cache.tags.header_reduced_ttl%'
 
     ezplatform.http_cache.user_context_provider.role_identify:
         class: EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,6 +1,7 @@
 parameters:
     ezplatform.http_cache.controller.invalidatetoken.class: EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController
     ezplatform.http_cache.listener.vary_header.class: EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener
+    ezplatform.http_cache.tags.header_max_length: null
 
 services:
     ezplatform.http_cache.cache_manager:
@@ -50,6 +51,8 @@ services:
          - '%ezplatform.http_cache.tags.header%'
          - '@ezplatform.http_cache.purge_client'
          - '@ezplatform.http_cache.repository_tag_prefix'
+         - '@logger'
+         - '%ezplatform.http_cache.tags.header_max_length%'
 
     ezplatform.http_cache.user_context_provider.role_identify:
         class: EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30562](https://jira.ez.no/browse/EZP-30562)
| **Type**           | Bug/Improvement
| **Target version** |  `1.0`
| **BC breaks**      | no
| **Doc needed**     | yes

Even if 1.0 shortens tags, it still is possible to reach the limit. On Apache (4k) and Fastly (16k) this is supposedly not configurable, so this makes it possible to cut the header, and apply a lower TTL to compensate for the risk of stale cache.

Closes #104, which proposed this for 0.9. Feature fits better with 1.0 where tags are shortened, and which is new feature release.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
