### PR TITLE
EZP-31374: Cannot autowire service that has a dependency on TagHandler

### DIFF
--- a/src/DependencyInjection/Compiler/DriverPass.php
+++ b/src/DependencyInjection/Compiler/DriverPass.php
@@ -8,6 +8,7 @@ namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use EzSystems\PlatformHttpCacheBundle\Handler\TagHandler;
 
 /**
  * We support http cache drivers to be provided by 3rd party bundles.
@@ -35,7 +36,7 @@ class DriverPass implements CompilerPassInterface
         }
 
         $container->setAlias('fos_http_cache.handler.tag_handler', $configuredFosTagHandlerServiceId);
-        $container->setAlias('EzSystems\PlatformHttpCacheBundle\Handler\TagHandler', $configuredFosTagHandlerServiceId);
+        $container->setAlias(TagHandler::class, $configuredFosTagHandlerServiceId);
     }
 
     public static function getTaggedService(ContainerBuilder $container, $tag)

--- a/src/DependencyInjection/Compiler/DriverPass.php
+++ b/src/DependencyInjection/Compiler/DriverPass.php
@@ -35,6 +35,7 @@ class DriverPass implements CompilerPassInterface
         }
 
         $container->setAlias('fos_http_cache.handler.tag_handler', $configuredFosTagHandlerServiceId);
+        $container->setAlias('EzSystems\PlatformHttpCacheBundle\Handler\TagHandler', $configuredFosTagHandlerServiceId);
     }
 
     public static function getTaggedService(ContainerBuilder $container, $tag)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31374](https://jira.ez.no/browse/EZP-31374)
| **Type**           | Bug
| **Target version** | `0.9`
| **BC breaks**      | no
| **Doc needed**     | no

For more info please refer to JIRA ticket. 

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
