### PR TITLE
EZP-30560: Unable to clear Varnish cache on Platform.sh

### DIFF
--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -85,7 +85,7 @@ class VarnishPurgeClient implements PurgeClientInterface
     private function getPurgeHeaders()
     {
         $host = parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST);
-        $fallbackHost = $_SERVER['SERVER_NAME'] ?? 'localhost';
+        $fallbackHost = empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME']) : 'localhost';
 
         $headers = [
             'Host' => $host ?: $fallbackHost,

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -84,8 +84,11 @@ class VarnishPurgeClient implements PurgeClientInterface
      */
     private function getPurgeHeaders()
     {
+        $host = parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST);
+        $fallbackHost = $_SERVER['SERVER_NAME'] ?? 'localhost';
+
         $headers = [
-            'Host' => $this->getPurgeHost(),
+            'Host' => $host ?: $fallbackHost,
         ];
 
         if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)
@@ -95,27 +98,6 @@ class VarnishPurgeClient implements PurgeClientInterface
         }
 
         return $headers;
-    }
-
-    /**
-     * Extracts the value for Host header for Purge.
-     *
-     * @return string
-     */
-    private function getPurgeHost()
-    {
-        $purgeServers = $this->configResolver->hasParameter('http_cache.purge_servers')
-            ? $this->configResolver->getParameter('http_cache.purge_servers')
-            : [];
-
-        if (is_array($purgeServers) && count($purgeServers)) {
-            $configHost = parse_url($purgeServers[0], PHP_URL_HOST);
-            if ($configHost) {
-                return $configHost;
-            }
-        }
-
-        return $_SERVER['SERVER_NAME'];
     }
 
     /**

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -85,7 +85,7 @@ class VarnishPurgeClient implements PurgeClientInterface
     private function getPurgeHeaders()
     {
         $host = parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST);
-        $fallbackHost = empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME']) : 'localhost';
+        $fallbackHost = empty($_SERVER['SERVER_NAME']) ? 'localhost' : $_SERVER['SERVER_NAME'];
 
         $headers = [
             'Host' => $host ?: $fallbackHost,

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -84,10 +84,8 @@ class VarnishPurgeClient implements PurgeClientInterface
      */
     private function getPurgeHeaders()
     {
-        $host = parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST);
-
         $headers = [
-            'Host' => $host ?: $_SERVER['SERVER_NAME'],
+            'Host' => $this->getPurgeHost(),
         ];
 
         if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)
@@ -97,6 +95,27 @@ class VarnishPurgeClient implements PurgeClientInterface
         }
 
         return $headers;
+    }
+
+    /**
+     * Extracts the value for Host header for Purge.
+     *
+     * @return string
+     */
+    private function getPurgeHost()
+    {
+        $purgeServers = $this->configResolver->hasParameter('http_cache.purge_servers')
+            ? $this->configResolver->getParameter('http_cache.purge_servers')
+            : [];
+
+        if (is_array($purgeServers) && count($purgeServers)) {
+            $configHost = parse_url($purgeServers[0], PHP_URL_HOST);
+            if ($configHost) {
+                return $configHost;
+            }
+        }
+
+        return $_SERVER['SERVER_NAME'];
     }
 
     /**

--- a/src/PurgeClient/VarnishPurgeClient.php
+++ b/src/PurgeClient/VarnishPurgeClient.php
@@ -84,8 +84,10 @@ class VarnishPurgeClient implements PurgeClientInterface
      */
     private function getPurgeHeaders()
     {
+        $host = parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST);
+
         $headers = [
-            'Host' => empty($_SERVER['SERVER_NAME']) ? parse_url($this->configResolver->getParameter('http_cache.purge_servers')[0], PHP_URL_HOST) : $_SERVER['SERVER_NAME'],
+            'Host' => $host ?: $_SERVER['SERVER_NAME'],
         ];
 
         if ($this->configResolver->hasParameter(self::INVALIDATE_TOKEN_PARAM)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30560](https://jira.ez.no/browse/EZP-30560)
| **Type**           | Bug
| **Target version** | `0.9`
| **BC breaks**      | no
| **Doc needed**     | no

Let's say there is eZ Platform site on Platform.sh. Own domain is used to access the admin. So site has following domains:
- https://project.com for front-end
- https://admin.project.com for admin UI

Front-end (https://project.com) is served by Varnish, but admin is not:
```
// .platform/routes.yaml
https://project.com:
    type: upstream
    upstream: varnish:http
https://admin.project.com:
    type: upstream
    upstream: app:http
```

When you edit/publish some content in admin UI (https://admin.project.com), it is expected that its Varnish cache will be cleared. But actually, the Varnish cache is not cleared.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
