### PR TITLE
EZP-31493: Removed http as valid purge type

### DIFF
--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -37,9 +37,6 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
         $loader->load('services.yml');
         $loader->load('event.yml');
         $loader->load('view_cache.yml');
-
-        $this->setDefaultResponseHeader($container);
-        $this->setDefaultTagSeparator($container);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -68,29 +65,5 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
     public function getExtraConfigParsers()
     {
         return $this->extraConfigParsers;
-    }
-
-    /**
-     * Overrides default header name based on setting tag_mode in FosHttpCacheBundle configuration.
-     */
-    private function setDefaultResponseHeader(ContainerBuilder $container): void
-    {
-        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
-
-        $responseHeader = 'http' === $purgeType ? 'xkey' : TagHeaderFormatter::DEFAULT_HEADER_NAME;
-
-        $container->setParameter('fos_http_cache.tag_handler.response_header', $responseHeader);
-    }
-
-    /**
-     * Overrides default header separator based on setting tag_mode in FosHttpCacheBundle configuration.
-     */
-    private function setDefaultTagSeparator(ContainerBuilder $container): void
-    {
-        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
-
-        $separator = 'http' === $purgeType ? ' ' : ',';
-
-        $container->setParameter('fos_http_cache.tag_handler.separator', $separator);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -43,7 +43,6 @@ services:
         arguments:
             - '@fos_http_cache.cache_manager'
         tags:
-            - {name: ezplatform.http_cache.purge_client, purge_type: http}
             - {name: ezplatform.http_cache.purge_client, purge_type: varnish}
 
     ezplatform.http_cache.purge_client.local:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31493](https://jira.ez.no/browse/EZP-31493)
| **Type**           | Misc
| **Target version** | `master` for new features
| **BC breaks**      | yes
| **Doc needed**     | yes

It seems that based on platform.sh configuration only `varnish` is proper purge_type, so it seems to be better to remove one and stick with `varnish` instead of `http` as it also seems exacly what Fos did.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
