### PR TITLE
EZP-31505: Varnish config is loaded only when varnish set as purge_type

### DIFF
--- a/src/DependencyInjection/Compiler/VarnishCachePass.php
+++ b/src/DependencyInjection/Compiler/VarnishCachePass.php
@@ -6,23 +6,26 @@
  */
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler;
 
+use EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
 
 class VarnishCachePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('fos_http_cache.proxy_client.varnish')) {
+            $container->removeDefinition('ezplatform.http_cache.proxy_client.varnish.http_dispatcher');
+            return;
+        }
+
+        $this->overrideDefaultProxyClient($container);
         $this->processVarnishProxyClientSettings($container);
     }
 
-    private function processVarnishProxyClientSettings(ContainerBuilder $container)
+    private function processVarnishProxyClientSettings(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('fos_http_cache.proxy_client.varnish')) {
-            throw new InvalidArgumentException('Varnish proxy client must be enabled in FOSHttpCacheBundle');
-        }
-
         $fosConfig = array_merge(...$container->getExtensionConfig('fos_http_cache'));
 
         $servers = $fosConfig['proxy_client']['varnish']['http']['servers'] ?? [];
@@ -37,5 +40,16 @@ class VarnishCachePass implements CompilerPassInterface
             'ezplatform.http_cache.varnish.http.base_url',
             $baseUrl
         );
+    }
+
+    private function overrideDefaultProxyClient(ContainerBuilder $container): void
+    {
+        $varnishProxyClient = $container->getDefinition('fos_http_cache.proxy_client.varnish');
+        $varnishProxyClient->setClass(Varnish::class);
+        $varnishProxyClient->setArguments([
+            new Reference('ezpublish.config.resolver'),
+            new Reference('fos_http_cache.proxy_client.varnish.http_dispatcher'),
+            $container->getParameter('fos_http_cache.proxy_client.varnish.options'),
+        ]);
     }
 }

--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -31,12 +31,20 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
+        $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('event.yml');
         $loader->load('view_cache.yml');
+
+        if ($container->getParameter('ezpublish.http_cache.purge_type') === 'varnish') {
+            // Load default varnish config
+            $configFile = __DIR__ . '/../Resources/config/fos_http_cache_varnish.yml';
+            $config = Yaml::parse(file_get_contents($configFile));
+            $container->prependExtensionConfig('fos_http_cache', $config);
+            $container->addResource(new FileResource($configFile));
+        }
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -35,8 +35,9 @@ final class Varnish extends FosVarnish implements BanCapable, PurgeCapable, Refr
 
     private function fetchAndMergeAuthHeaders(array $headers): array
     {
-        if ($this->configResolver->hasParameter('http_cache.varnish_invalidate_token')) {
-            $headers[InvalidateTokenController::TOKEN_HEADER_NAME] = $this->configResolver->getParameter('http_cache.varnish_invalidate_token');
+        if ($this->configResolver->hasParameter('http_cache.varnish_invalidate_token') &&
+            '' !== $token = $this->configResolver->getParameter('http_cache.varnish_invalidate_token')) {
+            $headers[InvalidateTokenController::TOKEN_HEADER_NAME] = $token;
         }
 
         return $headers;

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -35,9 +35,11 @@ final class Varnish extends FosVarnish implements BanCapable, PurgeCapable, Refr
 
     private function fetchAndMergeAuthHeaders(array $headers): array
     {
-        if ($this->configResolver->hasParameter('http_cache.varnish_invalidate_token') &&
-            '' !== $token = $this->configResolver->getParameter('http_cache.varnish_invalidate_token')) {
-            $headers[InvalidateTokenController::TOKEN_HEADER_NAME] = $token;
+        if ($this->configResolver->hasParameter('http_cache.varnish_invalidate_token')) {
+            $token = $this->configResolver->getParameter('http_cache.varnish_invalidate_token');
+            if ('' !== $token) {
+                $headers[InvalidateTokenController::TOKEN_HEADER_NAME] = $token;
+            }
         }
 
         return $headers;

--- a/src/Resources/config/fos_http_cache.yml
+++ b/src/Resources/config/fos_http_cache.yml
@@ -1,9 +1,7 @@
 proxy_client:
-    default: varnish
-    varnish:
+    symfony:
         http:
             servers: ['$http_cache.purge_servers$']
-        tag_mode: 'purgekeys'
 
 user_context:
     enabled: true

--- a/src/Resources/config/fos_http_cache_varnish.yml
+++ b/src/Resources/config/fos_http_cache_varnish.yml
@@ -1,0 +1,6 @@
+proxy_client:
+    default: varnish
+    varnish:
+        http:
+            servers: ['$http_cache.purge_servers$']
+        tag_mode: 'purgekeys'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -96,10 +96,3 @@ services:
         class: EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix
         # Use config resolver to be able to lazy load reading SA setting "repository" to avoid scope change issues
         arguments: ["@ezpublish.config.resolver", '%ezpublish.repositories%']
-
-    fos_http_cache.proxy_client.varnish:
-        class: EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish
-        arguments:
-            $configResolver: '@ezpublish.config.resolver'
-            $httpDispatcher: '@fos_http_cache.proxy_client.varnish.http_dispatcher'
-            $options: '%fos_http_cache.proxy_client.varnish.options%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31505](https://jira.ez.no/browse/EZP-31505)
| **Type**           | Bug
| **Target version** |  `master`
| **Doc needed**     | no

Instead of changing default variables that are set by fos when varnish config is used, that yaml file is only included when `varnish` is set as `purge_type`.
That involved change in order of bundle loading:
https://github.com/ezsystems/ezplatform/pull/512

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
