### PR TITLE
Restored FOS header and separator override for local purge type

### DIFF
--- a/src/DependencyInjection/EzPlatformHttpCacheExtension.php
+++ b/src/DependencyInjection/EzPlatformHttpCacheExtension.php
@@ -7,6 +7,7 @@
 namespace EzSystems\PlatformHttpCacheBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
+use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -36,6 +37,15 @@ class EzPlatformHttpCacheExtension extends Extension implements PrependExtension
         $loader->load('services.yml');
         $loader->load('event.yml');
         $loader->load('view_cache.yml');
+
+        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
+        if ('local' === $purgeType) {
+            $container->setParameter(
+                'fos_http_cache.tag_handler.response_header',
+                TagHeaderFormatter::DEFAULT_HEADER_NAME
+            );
+            $container->setParameter('fos_http_cache.tag_handler.separator', ',');
+        }
     }
 
     public function prepend(ContainerBuilder $container)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow up to [EZP-31493](https://jira.ez.no/browse/EZP-31493) (#120)
| **Type**           | Bug
| **Target version** | `master`
| **BC breaks**      | no
| **Doc needed**     | no

### Summary

While `http` purge type is no longer needed for Varnish, #120 also removed overriding FOS Sf Container parameters for `local` purge type. It is still default purge type available for any environment other than dev. The following FOSHttpCache parameters were restored:
- `fos_http_cache.tag_handler.response_header`
- `fos_http_cache.tag_handler.separator`

I've discovered this issue while debugging [REST failure](https://travis-ci.org/github/ezsystems/ezplatform-rest/jobs/664966144#L1305). Please observe that when meta is set with the branch from this PR it [no longer fails](https://travis-ci.org/github/ezsystems/ezplatform-rest/jobs/665053373).

### Further issues

I'm not that familiar with HTTP cache, so it was a bit of trial and error attempt to unblock entire CI. Unfortunately this means that ezsystems/ezplatform#512 will create this regression once again because FOS will override those settings.

I have a feeling the approach here is not the best and can be configured differently, but no idea how (TL;DR; FOSHttpCache doc). Unless it no longer supports anything other than Varnish?

Alternatively maybe instead of using `X-Cache-Tags` (`TagHeaderFormatter::DEFAULT_HEADER_NAME`) we could use `xkey` and space as separator for `local` as well? If this is nonsense, forgive me :-)

**TODO**:
- [x] Restore FOSHttpCache parameters override which cause local purge type to fail.
- [x] Wait for Travis (at least for jobs which should pass now).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
