### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 # platform-http-cache
 
-Provides HTTP cache handling for [eZ Platform][ezplatform], by default since version 1.12. From [ezpublish-kernel](ezpublish-kernel),
-it adds support for mult-tagging for Symfony Proxy, Varnish _(using [xkey][Varnish-xkey])_. Support for Fastly is part of the
+Provides HTTP cache handling for [eZ Platform][ezplatform], by default since version 1.12. It adds support for multi-tagging for Symfony Proxy, Varnish _(using [xkey][Varnish-xkey])_. Support for Fastly is part of the
 eZ Platform Cloud Enterprise offer as of 1.13 LTS.
 
 
@@ -72,5 +71,5 @@ For further reading on tags see [docs/using_tags.md](docs/using_tags.md).
 
 
 [ezplatform]: http://github.com/ezsystems/ezplatform
-[ezpublish-kernel]: http://github.com/ezsystems/ezpubish-kernel
+[ezplatform-kernel]: http://github.com/ezsystems/ezplatform-kernel
 [Varnish-xkey]: https://github.com/varnish/varnish-modules/blob/master/docs/vmod_xkey.rst

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "ezsystems/ezplatform-rest": "^1.0@dev",
         "friendsofsymfony/http-cache-bundle": "^2.8",
         "friendsofsymfony/http-cache": "^2.9",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` both in composer and some relevant docs.

#### TODO
- [ ] Wait for Travis