### PR TITLE
EZP-30543: Removed Dynamic Settings functionality from kernel

### DIFF
--- a/src/Resources/config/view_cache.yml
+++ b/src/Resources/config/view_cache.yml
@@ -50,10 +50,7 @@ services:
     ezplatform.view_cache.response_configurator:
         class: EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator
         arguments:
-            - '$content.view_cache$'
-            - '$content.ttl_cache$'
-            - '$content.default_ttl$'
-            - '@fos_http_cache.http.symfony_response_tagger'
+            - '@ezpublish.config.resolver'
 
     # ResponseTagger dispatcher
     ezplatform.view_cache.response_tagger.dispatcher:

--- a/src/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
+++ b/src/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
@@ -54,6 +54,6 @@ class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
 
     private function getDefaultTTL(): int
     {
-        return $this->configResolver->getParameter('content.default_ttl');
+        return (int)$this->configResolver->getParameter('content.default_ttl');
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30543](https://jira.ez.no/browse/EZP-30543)
| **Type**           | Improvement
| **Target version** | l`master`
| **BC breaks**      | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

**TODO**:
- [x] Remove dynamic settings from `\EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator`
- [ ] Remove dynamic settings from `src/Resources/config/fos_http_cache.yml`
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
