### PR TITLE
README.md: update xkey example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Connection: close
 Cache-Control: public, s-maxage=60
 Content-Type: text/html; charset=UTF-8
 Vary: X-User-Hash
-xkey: content-1 content-type-1 location-2 parent-1 path-1 path-2 ez-all
+xkey: ez-all c1 ct1 l2 pl1 p1 p2
 ```
 
 _As of v0.7, if you have several repositories configured, the tags will be prefixed by
-repository name on non default repository. E.g. "intranet_path-1"._
+repository name on non default repository. E.g. "intranet_p1"._
 
 For further reading on tags see [docs/using_tags.md](docs/using_tags.md).
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ xkey: ez-all c1 ct1 l2 pl1 p1 p2
 ```
 
 _As of v0.7, if you have several repositories configured, the tags will be prefixed by
-repository name on non default repository. E.g. "intranet_p1"._
+repository name on non default repository. E.g. "1p1", where repository is the second repository in the system (default repository has index 0 but does not have prefix)._
 
 For further reading on tags see [docs/using_tags.md](docs/using_tags.md).
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Type**           | Misc
| **Target version** | latest stable `1.0` and `2.0` for doc fixes, `master` for new featured doc
| **BC breaks**      | no
| **Doc needed**     | yes

xkey [example](https://github.com/ezsystems/ezplatform-http-cache/blob/v1.0.0/README.md) and [documentation](https://doc.ezplatform.com/en/2.5/guide/http_cache/#available-tags) doesn't seem to reflect [reality](https://github.com/ezsystems/ezplatform-http-cache/blob/v1.0.0/docs/using_tags.md).
* With eZ Platform 2.5.9 using fresh `composer ezplatform-install` and ezsystems/ezplatform-http-cache v1.0.0, for the root, I have `xkey: ez-all c52 l2 ct42 pl1 p1 p2`
* With eZ Platform 3.0.0 using fresh `composer ezplatform-install` and ezsystems/ezplatform-http-cache v2.0.0, for the root, I have `xkey: c52 ct42 l2 pl1 p1 p2`

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
