### PR TITLE
EZP-30465: Aligned tests with Permission Resolver changes

### DIFF
--- a/tests/ContextProvider/RoleIdentifyTest.php
+++ b/tests/ContextProvider/RoleIdentifyTest.php
@@ -12,12 +12,9 @@ use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\API\Repository\Values\User\UserReference;
-use eZ\Publish\Core\Repository\Permission\LimitationService;
-use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
-use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify;
 use FOS\HttpCache\UserContext\UserContext;
 use PHPUnit\Framework\TestCase;
@@ -183,14 +180,7 @@ class RoleIdentifyTest extends TestCase
         return $this
             ->getMockBuilder(PermissionResolver::class)
             ->setMethods(['getCurrentUserReference'])
-            ->setConstructorArgs(
-                [
-                    $this->createMock(RoleDomainMapper::class),
-                    $this->createMock(LimitationService::class),
-                    $this->createMock(SPIUserHandler::class),
-                    $this->createMock(UserReference::class),
-                ]
-            )
+            ->disableOriginalConstructor()
             ->getMock();
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30465](https://jira.ez.no/browse/EZP-30465)
| **Type**           | Bug
| **Target version** | `2.0@dev` for eZ Platform `v3.0.x`
| **BC breaks**      | no
| **Doc needed**     | no

The signature of `PermissionResolver` constructor has been changed via  ezsystems/ezplatform-kernel#44. One test here relied on that. Updated it so it does not, as it's not relevant for the test itself.

**TODO**:
- [x] Fix a bug in tests.
- [x] tests + specs are passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis
- [x] Ask for Code Review.
