### PR TITLE
Fix Adding X-Invalidate-Token header only when TOKEN is not null

### DIFF
--- a/spec/ProxyClient/VarnishSpec.php
+++ b/spec/ProxyClient/VarnishSpec.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace spec\EzSystems\PlatformHttpCacheBundle\ProxyClient;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use FOS\HttpCache\ProxyClient\Dispatcher;
+use Http\Message\RequestFactory;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+
+class VarnishSpec extends ObjectBehavior
+{
+    private const URI = "/";
+    private const REQUEST_HEADERS = [
+        "X-Some-Header" => "__SOME_HEADER_VALUE__"
+    ];
+
+    public function let(
+        ConfigResolverInterface $configResolver,
+        Dispatcher $httpDispatcher,
+        RequestFactory $messageFactory,
+        RequestInterface $request
+
+    ) {
+        $messageFactory->createRequest(
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any()
+        )->willReturn($request);
+
+        $this->beConstructedWith($configResolver, $httpDispatcher, [], $messageFactory);
+    }
+
+    public function it_should_purge_with_additional_token_header_when_configuration_key_with_token_is_not_null(
+        ConfigResolverInterface $configResolver,
+        RequestFactory $messageFactory
+    ) {
+        $configResolver->hasParameter('http_cache.varnish_invalidate_token')->willReturn(true);
+        $configResolver->getParameter('http_cache.varnish_invalidate_token')->willReturn('__TOKEN__');
+
+        $this->purge(self::URI, self::REQUEST_HEADERS);
+
+        $this->requestShouldHaveBeenCreatedWithHeaders(
+            array_merge(self::REQUEST_HEADERS, ["X-Invalidate-Token" => "__TOKEN__"]),
+            $messageFactory
+        );
+    }
+
+    public function it_should_purge_without_additional_token_header_when_configuration_key_with_token_do_not_exist_in_configuration(
+        ConfigResolverInterface $configResolver,
+        RequestFactory $messageFactory
+    ) {
+        $configResolver->hasParameter('http_cache.varnish_invalidate_token')->willReturn(false);
+
+        $this->purge(self::URI, self::REQUEST_HEADERS);
+
+        $this->requestShouldHaveBeenCreatedWithHeaders(
+            self::REQUEST_HEADERS,
+            $messageFactory
+        );
+    }
+
+    public function it_should_purge_without_additional_token_header_when_configuration_key_with_token_exists_but_is_null(
+        ConfigResolverInterface $configResolver,
+        RequestFactory $messageFactory
+    ) {
+        $configResolver->hasParameter('http_cache.varnish_invalidate_token')->willReturn(true);
+        $configResolver->getParameter('http_cache.varnish_invalidate_token')->willReturn(null);
+
+        $this->purge(self::URI, self::REQUEST_HEADERS);
+
+        $this->requestShouldHaveBeenCreatedWithHeaders(
+            self::REQUEST_HEADERS,
+            $messageFactory
+        );
+    }
+
+    private function requestShouldHaveBeenCreatedWithHeaders($headers, RequestFactory $messageFactory)
+    {
+        $messageFactory->createRequest(
+            'PURGE',
+            self::URI,
+            $headers,
+            Argument::any()
+        )->shouldHaveBeenCalled();
+    }
+}

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -35,11 +35,21 @@ final class Varnish extends FosVarnish implements BanCapable, PurgeCapable, Refr
 
     private function fetchAndMergeAuthHeaders(array $headers): array
     {
-        if ($this->configResolver->hasParameter('http_cache.varnish_invalidate_token')) {
-            $headers[InvalidateTokenController::TOKEN_HEADER_NAME] = $this->configResolver->getParameter('http_cache.varnish_invalidate_token');
+        $invalidateToken = $this->getInvalidateToken();
+        if (null !== $invalidateToken) {
+            $headers[InvalidateTokenController::TOKEN_HEADER_NAME] = $invalidateToken;
         }
 
         return $headers;
+    }
+
+    private function getInvalidateToken(): ?string
+    {
+        if ($this->configResolver->hasParameter('http_cache.varnish_invalidate_token')) {
+            return $this->configResolver->getParameter('http_cache.varnish_invalidate_token');
+        }
+
+        return null;
     }
 
     protected function queueRequest($method, $url, array $headers, $validateHost = true, $body = null)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31607](https://jira.ez.no/browse/EZP-31607)
| **Type**           | Bug
| **Target version** | `2.0`
| **BC breaks**      | no
| **Doc needed**     | no

Prevent attaching X-Invalidate-Token header to Varnish request when http_cache.varnish_invalidate_token parameter is not set or null.

**TODO**:
- [x] Implement fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
