### PR TITLE
[Tests] Added ClockMock to make time-sensitive tests more robust

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "phpspec/phpspec": "^5.1.2",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16.1",
-        "memio/spec-gen": "^0.9.0"
+        "memio/spec-gen": "^0.9.0",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,12 @@
   >
   <php>
     <ini name="error_reporting" value="-1" />
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1"/>
   </php>
     <testsuites>
         <testsuite name="default"><directory>tests</directory></testsuite>
     </testsuites>
+  <listeners>
+    <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
 </phpunit>

--- a/tests/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/PurgeClient/LocalPurgeClientTest.php
@@ -4,29 +4,23 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient;
-
-/**
- * Avoid test failure caused by time passing between generating expected & actual object.
- *
- * @return int
- */
-function time()
-{
-    return 1417624982;
-}
-
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests;
 
 use EzSystems\PlatformHttpCacheBundle\RequestAwarePurger;
 use EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bridge\PhpUnit\ClockMock;
 
 class LocalPurgeClientTest extends TestCase
 {
+    /**
+     * @group time-sensitive
+     */
     public function testPurge()
     {
+        ClockMock::register(Request::class);
+
         $locationIds = [123, 456, 789];
         $expectedBanRequest = Request::create('http://localhost', 'PURGE');
         $expectedBanRequest->headers->set('key', 'l123 l456 l789');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Type**           | Improvement in tests
| **Target version** | 1.0, needs to be adapted in 2.1 and master (1)
| **BC breaks**      | no
| **Doc needed**     | no

Failing build: https://travis-ci.org/github/ezsystems/ezplatform-http-cache/jobs/725689032

```
1) eZ\Publish\Core\MVC\Symfony\Cache\Tests\LocalPurgeClientTest::testPurge

Expectation failed for method name is equal to 'purgeByRequest' when invoked 1 time(s)

Parameter 0 for invocation EzSystems\PlatformHttpCacheBundle\RequestAwarePurger::purgeByRequest(Symfony\Component\HttpFoundation\Request Object (...)) does not match expected value.

Failed asserting that two objects are equal.

--- Expected

+++ Actual

@@ @@

             'SCRIPT_NAME' => ''
             'SCRIPT_FILENAME' => ''
             'SERVER_PROTOCOL' => 'HTTP/1.1'
-            'REQUEST_TIME' => 1599682188
+            'REQUEST_TIME' => 1599682189
             'PATH_INFO' => ''
             'REQUEST_METHOD' => 'PURGE'
             'REQUEST_URI' => '/'
```

`Request::create` uses `time()` method under the hood to set the `REQUEST_TIME` header. By using the ClockMock (as described in https://symfony.com/doc/3.4/components/phpunit_bridge.html#time-sensitive-tests) we can make sure that the `time` call in `Request` class is mocked and we're not hit by this issue again

There are 2 deprecation warnings in current tests:
```
OK, but incomplete, skipped, or risky tests!
Tests: 3385, Assertions: 3881, Skipped: 162, Incomplete: 4.

Remaining direct deprecation notices (1)

  1x: The eZ\Publish\Core\SignalSlot\Signal\ContentService\RemoveTranslationSignal is deprecated since 6.13 and will be removed in 7.0. Use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteTranslationSignal instead
    1x in RemoveTranslationSlotTest::getReceivedSignals from EzSystems\PlatformHttpCacheBundle\Tests\SignalSlot

Other deprecation notices (1)

  1x: The eZ\Publish\Core\Repository\Repository::getCurrentUser method is deprecated (since 6.6, to be removed. Use PermissionResolver::getCurrentUserReference() instead.  Get current user.  Loads the full user object if not already loaded, if you only need to know user id use {@see getCurrentUserReference()}).
    1x in RoleIdentifyTest::testSetIdentity from EzSystems\PlatformHttpCacheBundle\Tests\ContextProvider
```

I've disabled them as described in https://symfony.com/doc/3.4/components/phpunit_bridge.html#disabling-the-deprecation-helper, because I don't want to introduce too many changes here.




(1) In 2.1 and master the whole request is not compared:
https://github.com/ezsystems/ezplatform-http-cache/blob/2.1/tests/PurgeClient/LocalPurgeClientTest.php
so the test is not time-sensitive, but I think we can keep the dependency for future usages.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
