### PR TITLE
Fix discrepancy between doc and twig template name

### DIFF
--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -40,6 +40,11 @@ class ContentTaggingExtension extends AbstractExtension
                 'ez_http_cache_tag_location',
                 [$this, 'tagHttpCacheForLocation']
             ),
+            // For 2.5 BC, and to be consistent with the other functions, to be cleaned up with new prefix in the future
+            new TwigFunction(
+                'ez_http_tag_location',
+                [$this, 'tagHttpCacheForLocation']
+            ),
             new TwigFunction(
                 'ez_http_tag_relation_ids',
                 [$this, 'tagHttpCacheForRelationIds']


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | EZP-XXXXX
| **Type**           | Bug
| **Target version** | 2.1+
| **BC breaks**      | no, rather a BC fix depending on how you look at it
| **Doc needed**     | no, doc is already correct if this is merged

Fixing name break in 3.0, as both doc, and the other methods have different syntax by now I suggest we simply close this in the following way, and cleanup when moving to new prefixes at some point in the future. _IMO maybe with a bit better BC next time though._

Reported in: https://github.com/ezsystems/developer-documentation/pull/1132#discussion_r497281925


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
