### PR TITLE
EZP-32020: make /_ez_http_invalidatetoken cached by varnish

### DIFF
--- a/src/Controller/InvalidateTokenController.php
+++ b/src/Controller/InvalidateTokenController.php
@@ -10,6 +10,7 @@ use FOS\HttpCache\ResponseTagger;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
 
 class InvalidateTokenController
 {
@@ -74,6 +75,8 @@ class InvalidateTokenController
         $headers->set('X-Invalidate-Token', $this->configResolver->getParameter('http_cache.varnish_invalidate_token'));
         $response->setSharedMaxAge($this->ttl);
         $response->setVary('Accept', true);
+        // header to avoid Symfony SessionListener overwriting the response to private
+        $response->headers->set(SessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
 
         return $response;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32020](https://jira.ez.no/browse/EZP-32020)
| **Type**           | Bug
| **Target version** | `2.1`+
| **BC breaks**      | no
| **Doc needed**     | no

Currently, each request to purge cache by tags triggers a request to "/_ez_http_invalidatetoken" route
A response of this route should be cached by varnish, but it's not.
It's caused by session usage, and the fact this response does not vary by user context.
So, Symfony listener changing response to private.

PS. the same `NO_AUTO_CACHE_CONTROL_HEADER` used in fos symfony cache bundle

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
