### PR TITLE
EZP-32103: Add Varnish integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,27 @@ matrix:
             - SYMFONY_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
             - USER_RUNNING_TESTS=root
             - PHP_IMAGE=ezsystems/php:7.3-v1
-        - name: "PHP 7.3 Symfony Cache tests"
+        - name: "PHP 7.3 Symfony Cache integration tests"
           php: 7.3
           env:
-            - TEST_CMD="bin/ezbehat --profile=httpCache --suite=symfonycache"
+            - TEST_CMD="bin/ezbehat --mode=standard --profile=httpCache --suite=symfonycache"
+            - WEB_HOST="web"
             - APP_DEBUG=1
+        - name: "PHP 7.3 Varnish integration tests"
+          php: 7.3
+          env:
+            - TEST_CMD="bin/ezbehat --mode=standard --profile=httpCache --suite=varnish"
+            - APP_DEBUG=1
+            - WEB_HOST=varnish
+            - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
+        - name: "PHP 7.3 Varnish integration tests with invalidate token"
+          php: 7.3
+          env:
+            - TEST_CMD="bin/ezbehat --mode=standard --profile=httpCache --suite=varnish"
+            - HTTPCACHE_VARNISH_INVALIDATE_TOKEN=TESTTOKEN
+            - APP_DEBUG=1
+            - WEB_HOST=varnish
+            - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
 
 # test only master + stable (+ Pull requests)
 branches:

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -16,3 +16,20 @@ httpCache:
               - EzSystems\Behat\Browser\Context\Hooks
               - EzSystems\Behat\Browser\Context\FrontendContext:
                   argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'
+        varnish:
+            paths:
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/varnish'
+            filters:
+                tags: '@varnish'
+            contexts:
+              - EzSystems\Behat\API\Context\TestContext:
+                  userService: '@ezpublish.api.service.user'
+                  permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
+              - EzSystems\Behat\Core\Context\TimeContext
+              - EzSystems\Behat\API\Context\ContentContext:
+                  contentFacade: '@EzSystems\Behat\API\Facade\ContentFacade'
+                  argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'
+              - EzSystems\Behat\Browser\Context\BrowserContext
+              - EzSystems\Behat\Browser\Context\Hooks
+              - EzSystems\Behat\Browser\Context\FrontendContext:
+                  argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'

--- a/features/symfony/cache.feature
+++ b/features/symfony/cache.feature
@@ -19,9 +19,9 @@ Feature: As an site administrator I want my pages to be cached using Symfony Htt
 
 
     Examples:
-    | user      | itemName                     | headerValue                                   | 
-    | admin     | TestFolderShortNameAdmin     | GET /site/testfoldershortnameadmin: fresh     |
-    | anonymous | TestFolderShortNameAnonymous | GET /site/testfoldershortnameanonymous: fresh |
+      | user      | password | itemName                     | headerValue                                   |
+      | admin     | publish  | TestFolderShortNameAdmin     | GET /site/testfoldershortnameadmin: fresh     |
+      | anonymous |          | TestFolderShortNameAnonymous | GET /site/testfoldershortnameanonymous: fresh |
 
   @admin
   Scenario Outline: Cache is refreshed when item is edited
@@ -47,6 +47,6 @@ Feature: As an site administrator I want my pages to be cached using Symfony Htt
       | X-Symfony-Cache | <headerValue>          |
 
     Examples:
-      | user      | password | itemName        | itemNameAfterEdit | headerValue                      | 
+      | user      | password | itemName        | itemNameAfterEdit | headerValue                      |
       | admin     | publish  | NameToEditAdmin | NameEditedAdmin   | GET /site/nameeditedadmin: fresh |
       | anonymous |          | NameToEditAnon  | NameEditedAnon    | GET /site/nameeditedanon: fresh  |

--- a/features/varnish/cache.feature
+++ b/features/varnish/cache.feature
@@ -1,0 +1,60 @@
+@varnish
+Feature: As an site administrator I want my pages to be cached using Varnish
+
+    @admin
+    Scenario Outline: Content Items are cached for user when visited
+        Given I create "Folder" Content items in root in "eng-GB"
+            | name       | short_name |
+            | TestFolder | <itemName> |
+        And I am viewing the pages on siteaccess "site" as "<user>"
+        When I visit <itemName> on siteaccess "site"
+        And response headers contain
+            | Header  | Value |
+            | X-Cache | MISS  |
+        And I reload the page
+        Then I see correct preview data for "Folder" Content Type
+            | field | value      |
+            | title | <itemName> |
+        And response headers contain
+            | Header  | Value |
+            | X-Cache | HIT   |
+
+        Examples:
+            | user      | password | itemName                     |
+            | admin     | publish  | TestFolderShortNameAdmin     |
+            | anonymous |          | TestFolderShortNameAnonymous |
+
+    @admin
+    Scenario Outline: Cache is refreshed when item is edited
+        Given I create "Folder" Content items in root in "eng-GB"
+            | name       | short_name |
+            | TestFolder | <itemName> |
+        And I am viewing the pages on siteaccess "site" as "<user>" "<password>"
+        And I visit "<itemName>" on siteaccess "site"
+        And I reload the page
+        And I see correct preview data for "Folder" Content Type
+            | field | value      |
+            | title | <itemName> |
+        And response headers contain
+            | Header  | Value |
+            | X-Cache | HIT   |
+        When I edit "<itemName>" Content item in "eng-GB"
+            | short_name          |
+            | <itemNameAfterEdit> |
+        And I reload the page
+        # Give Varnish time to fetch the backend response
+        And I wait 5 seconds
+        # Second reload is needed because of soft purging
+        And I reload the page
+        And I reload the page
+        Then I see correct preview data for "Folder" Content Type
+            | field | value               |
+            | title | <itemNameAfterEdit> |
+        And response headers contain
+            | Header  | Value |
+            | X-Cache | HIT   |
+
+        Examples:
+            | user      | password | itemName        | itemNameAfterEdit |
+            | admin     | publish  | NameToEditAdmin | NameEditedAdmin   |
+            | anonymous |          | NameToEditAnon  | NameEditedAnon    |


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32103](https://issues.ibexa.co/browse/EZP-32103)
| **Type**           | Tests
| **Target version** | 2.1,2.2 and master
| **BC breaks**      | no
| **Doc needed**     | no

Requires: 
1) https://github.com/ezsystems/ezplatform/pull/621
2) https://github.com/ezsystems/BehatBundle/pull/166

Things done:
1) Fixed the test for Symfony cache meant for admin user - without password it was running as anonymous 😅 
2) Added two jobs running tests with Varnish - one with and one without invalidate token
3) Added basic tests for Varnish - making sure that pages are cached for anonymous and logged in users, also that the cache is refreshed correctly on Content changes.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] **Rebase before merging - remove TMP commit**