### PR TITLE
Deprecate ez_http_tag_location

### DIFF
--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -43,7 +43,8 @@ class ContentTaggingExtension extends AbstractExtension
             // For 2.5 BC, and to be consistent with the other functions, to be cleaned up with new prefix in the future
             new TwigFunction(
                 'ez_http_tag_location',
-                [$this, 'tagHttpCacheForLocation']
+                [$this, 'tagHttpCacheForLocation'],
+                ['deprecated' => true, 'alternative' => 'ez_http_cache_tag_location']
             ),
             new TwigFunction(
                 'ez_http_tag_relation_ids',

--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -53,7 +53,7 @@ class ContentTaggingExtension extends AbstractExtension
                 'ez_http_tag_location',
                 [$this, 'tagHttpCacheForLocation'],
                 [
-                    'deprecated' => true, 
+                    'deprecated' => true,
                     'alternative' => 'ez_http_cache_tag_location',
                 ]
             ),
@@ -61,7 +61,7 @@ class ContentTaggingExtension extends AbstractExtension
                 'ez_http_tag_relation_ids',
                 [$this, 'tagHttpCacheForRelationIds'],
                 [
-                    'deprecated' => true, 
+                    'deprecated' => true,
                     'alternative' => 'ez_http_cache_tag_relation_ids',
                 ]
             ),
@@ -69,7 +69,7 @@ class ContentTaggingExtension extends AbstractExtension
                 'ez_http_tag_relation_location_ids',
                 [$this, 'tagHttpCacheForRelationLocationIds'],
                 [
-                    'deprecated' => true, 
+                    'deprecated' => true,
                     'alternative' => 'ez_http_cache_tag_relation_location_ids',
                 ]
             ),

--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -40,6 +40,14 @@ class ContentTaggingExtension extends AbstractExtension
                 'ez_http_cache_tag_location',
                 [$this, 'tagHttpCacheForLocation']
             ),
+            new TwigFunction(
+                'ez_http_cache_tag_relation_ids',
+                [$this, 'tagHttpCacheForRelationIds']
+            ),
+            new TwigFunction(
+                'ez_http_cache_tag_relation_location_ids',
+                [$this, 'tagHttpCacheForRelationLocationIds']
+            ),
             // For 2.5 BC, and to be consistent with the other functions, to be cleaned up with new prefix in the future
             new TwigFunction(
                 'ez_http_tag_location',
@@ -51,11 +59,19 @@ class ContentTaggingExtension extends AbstractExtension
             ),
             new TwigFunction(
                 'ez_http_tag_relation_ids',
-                [$this, 'tagHttpCacheForRelationIds']
+                [$this, 'tagHttpCacheForRelationIds'],
+                [
+                    'deprecated' => true, 
+                    'alternative' => 'ez_http_cache_tag_relation_ids',
+                ]
             ),
             new TwigFunction(
                 'ez_http_tag_relation_location_ids',
-                [$this, 'tagHttpCacheForRelationLocationIds']
+                [$this, 'tagHttpCacheForRelationLocationIds'],
+                [
+                    'deprecated' => true, 
+                    'alternative' => 'ez_http_cache_tag_relation_location_ids',
+                ]
             ),
         ];
     }

--- a/src/Twig/ContentTaggingExtension.php
+++ b/src/Twig/ContentTaggingExtension.php
@@ -44,7 +44,10 @@ class ContentTaggingExtension extends AbstractExtension
             new TwigFunction(
                 'ez_http_tag_location',
                 [$this, 'tagHttpCacheForLocation'],
-                ['deprecated' => true, 'alternative' => 'ez_http_cache_tag_location']
+                [
+                    'deprecated' => true, 
+                    'alternative' => 'ez_http_cache_tag_location',
+                ]
             ),
             new TwigFunction(
                 'ez_http_tag_relation_ids',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Type**           | Improvement/Misc
| **Target version** | `master`
| **BC breaks**      | no
| **Doc needed**     | https://github.com/ezsystems/developer-documentation/pull/1297

Mark ez_http_tag_location as deprecated and ez_http_cache_tag_location as its alternative. If 2.5 BC is “to be cleaned up”, one should be informed to not using this and replace it.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
