### PR TITLE
IBX-116: More integration tests for HTTP cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
           php: 7.3
           env:
             - TEST_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=symfonycache -c=behat_ibexa_oss.yaml"
+            - SETUP_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=setup -c=behat_ibexa_oss.yaml"
             - WEB_HOST="http://web"
             - APP_DEBUG=1
             - ENABLE_SYMFONY_CACHE=1
@@ -43,6 +44,7 @@ matrix:
           php: 7.3
           env:
             - TEST_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=varnish -c=behat_ibexa_oss.yaml"
+            - SETUP_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=setup -c=behat_ibexa_oss.yaml"
             - APP_DEBUG=1
             - WEB_HOST="http://varnish"
             - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
@@ -50,6 +52,7 @@ matrix:
           php: 7.3
           env:
             - TEST_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=varnish -c=behat_ibexa_oss.yaml"
+            - SETUP_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=setup -c=behat_ibexa_oss.yaml"
             - HTTPCACHE_VARNISH_INVALIDATE_TOKEN=TESTTOKEN
             - APP_DEBUG=1
             - WEB_HOST="http://varnish"
@@ -69,6 +72,8 @@ before_script:
     # Execute Symfony command if injected into test matrix
     - if [ "${SYMFONY_CMD}" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user www-data app sh -c "APP_ENV=behat php bin/console ${SYMFONY_CMD}" ; fi
     - if [ "${ENABLE_SYMFONY_CACHE}" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user www-data app sh -c "patch -p1 -i vendor/ezsystems/ezplatform-http-cache/tests/SymfonyProxy/enable_symfony_proxy.patch" ; fi
+    - if [ "$SETUP_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "$SETUP_CMD"  ; fi
+    - if [ "$SETUP_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "composer run post-install-cmd"  ; fi
 
 script:
     - if [ "$UNIT_TEST" != "" ] ; then php vendor/bin/phpunit --coverage-text && php vendor/bin/phpspec run --format=pretty ; fi

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -6,30 +6,33 @@ httpCache:
             filters:
                 tags: '@symfonycache'
             contexts:
-              - EzSystems\Behat\API\Context\TestContext:
-                  userService: '@ezpublish.api.service.user'
-                  permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
-              - EzSystems\Behat\API\Context\ContentContext:
-                  contentFacade: '@EzSystems\Behat\API\Facade\ContentFacade'
-                  argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'
-              - EzSystems\Behat\Browser\Context\BrowserContext
-              - EzSystems\Behat\Browser\Context\Hooks
-              - EzSystems\Behat\Browser\Context\FrontendContext:
-                  argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'
+                - EzSystems\Behat\API\Context\TestContext
+                - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\API\Context\ContentContext
+                - EzSystems\Behat\Core\Context\TimeContext
+                - EzSystems\Behat\Core\Context\ConfigurationContext
+                - EzSystems\Behat\Browser\Context\BrowserContext
+                - EzSystems\Behat\Browser\Context\Hooks
+                - EzSystems\Behat\Browser\Context\FrontendContext
         varnish:
             paths:
                 - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/varnish'
             filters:
-                tags: '@varnish'
+                tags: '@varnish' 
             contexts:
-              - EzSystems\Behat\API\Context\TestContext:
-                  userService: '@ezpublish.api.service.user'
-                  permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
-              - EzSystems\Behat\Core\Context\TimeContext
-              - EzSystems\Behat\API\Context\ContentContext:
-                  contentFacade: '@EzSystems\Behat\API\Facade\ContentFacade'
-                  argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'
-              - EzSystems\Behat\Browser\Context\BrowserContext
-              - EzSystems\Behat\Browser\Context\Hooks
-              - EzSystems\Behat\Browser\Context\FrontendContext:
-                  argumentParser: '@EzSystems\Behat\Core\Behat\ArgumentParser'
+                - EzSystems\Behat\API\Context\TestContext
+                - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\Core\Context\TimeContext
+                - EzSystems\Behat\Core\Context\ConfigurationContext
+                - EzSystems\Behat\API\Context\ContentContext
+                - EzSystems\Behat\Browser\Context\BrowserContext
+                - EzSystems\Behat\Browser\Context\Hooks
+                - EzSystems\Behat\Browser\Context\FrontendContext
+        setup:
+            paths:
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup'
+            contexts:
+                - EzSystems\Behat\API\Context\TestContext
+                - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\Core\Context\ConfigurationContext
+                - EzSystems\Behat\API\Context\ContentContext

--- a/features/setup/setup.feature
+++ b/features/setup/setup.feature
@@ -1,0 +1,46 @@
+@setup
+Feature: Set system to desired state before tests
+  
+  @admin
+  Scenario: Set up the system to test caching of subrequests
+    Given I create a "embeddedContentType" Content Type in "Content" with "embeddedContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+    And I create "embeddedContentType" Content items in root in "eng-GB"
+      | name              |
+      | EmbeddedItemNoEsi |
+      | EmbeddedItemEsi   |
+    And I create a "embeddingContentType_no_esi" Content Type in "Content" with "embeddingContentType_no_esi" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+      | Content relation (single) | Relation  | relation   | yes      | no	       | yes          |
+    And I create "embeddingContentType_no_esi" Content items in root in "eng-GB"
+      | name               | relation           |
+      | EmbeddingItemNoEsi | /EmbeddedItemNoEsi |
+    And I create a "embeddingContentType_esi" Content Type in "Content" with "embeddingContentType_esi" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+      | Content relation (single) | Relation  | relation   | yes      | no	       | yes          |
+    And I create "embeddingContentType_esi" Content items in root in "eng-GB"
+      | name             | relation         |
+      | EmbeddingItemEsi | /EmbeddedItemEsi |
+    And I set configuration to "ezplatform.system.default.content_view"
+    """
+      full:
+        embeddingContentType_no_esi:
+            controller: EzSystems\BehatBundle\Controller\RenderController::embedAction
+            template: "@eZBehat/tests/cache/embed_no_esi.html.twig"
+            match:
+                Identifier\ContentType: [embeddingContentType_no_esi]
+        embeddingContentType_esi:
+            controller: EzSystems\BehatBundle\Controller\RenderController::embedAction
+            template: "@eZBehat/tests/cache/embed_esi.html.twig"
+            match:
+                Identifier\ContentType: [embeddingContentType_esi]
+      line:
+        embedded:
+            controller: EzSystems\BehatBundle\Controller\RenderController::longAction
+            template: "@eZBehat/tests/cache/embedded.html.twig"
+            match:
+                Identifier\ContentType: [embeddedContentType]
+    """

--- a/features/symfony/cache.feature
+++ b/features/symfony/cache.feature
@@ -6,7 +6,7 @@ Feature: As an site administrator I want my pages to be cached using Symfony Htt
     Given I create "Folder" Content items in root in "eng-GB"
       | name       | short_name |
       | TestFolder | <itemName> |
-    And I am viewing the pages on siteaccess "site" as <user>
+    And I am viewing the pages on siteaccess "site" as <user> "<password>"
     When I visit <itemName> on siteaccess "site"
     And I reload the page
     Then I see correct preview data for "Folder" Content Type
@@ -28,7 +28,7 @@ Feature: As an site administrator I want my pages to be cached using Symfony Htt
     Given I create "Folder" Content items in root in "eng-GB"
       | name       | short_name |
       | TestFolder | <itemName> |
-    And I am viewing the pages on siteaccess "site" as "<user>" "<password>"
+    And I am viewing the pages on siteaccess "site" as "<user>" with password "<password>"
     And I visit "<itemName>" on siteaccess "site"
     And I see correct preview data for "Folder" Content Type
       | field | value      |

--- a/features/symfony/embed.feature
+++ b/features/symfony/embed.feature
@@ -1,0 +1,64 @@
+@symfonycache
+Feature: Caching of embedded items
+
+  @admin
+  Scenario Outline: Editing an embedded item refreshes the embedding item as well
+    Given I create a "embeddedContentType" Content Type in "Content" with "embeddedContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+    And I create "embeddedContentType" Content items in root in "eng-GB"
+      | name               |
+      | <embeddedItemName> |
+    And I create a "embeddingContentType" Content Type in "Content" with "embeddingContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+      | Content relation (single) | Relation  | relation   | yes      | no	       | yes          |
+    And I create "embeddingContentType" Content items in root in "eng-GB"
+      | name                | relation            |
+      | <embeddingItemName> | /<embeddedItemName> |
+    And I am viewing the pages on siteaccess "site" as "<user>" with password "<password>"
+    And I visit "/<embeddingItemName>" on siteaccess "site"
+    And I reload the page
+    And I should see "<embeddingItemName>"
+    And I should see "<embeddedItemName>"
+    And response headers contain
+      | Header          | Value                  |
+      | Cache-Control   | public, s-maxage=86400 |
+      | X-Symfony-Cache | <headerValue>          |
+    When I edit "<embeddedItemName>" Content item in "eng-GB"
+      | name                     |
+      | <editedEmbeddedItemName> | 
+    And I reload the page
+    And I reload the page
+    Then I should see "<embeddingItemName>"
+    And I should see "<editedEmbeddedItemName>"
+
+    Examples:
+      | user      | password | embeddingItemName  | embeddedItemName  | editedEmbeddedItemName  | headerValue                         |
+      | admin     | publish  | EmbeddingItemAdmin | AdminEmbeddedItem | EditedEmbeddedItemAdmin | GET /site/embeddingitemadmin: fresh |
+      | anonymous |          | EmbeddingItemAnon  | AnonEmbeddedItem  | EditedEmbeddedItemAnon  | GET /site/embeddingitemanon: fresh  |
+
+
+  Scenario Outline: Embedded requests are cached
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I start measuring time
+    And I visit "/<embeddingItemName>" on siteaccess "site"
+    And the action took longer than 5 seconds
+    And I should see "<embeddingItemName>"
+    And I should see "<embeddedItemName>"
+    When I start measuring time
+    And I reload the page
+    Then the action took no longer than 1 seconds
+    And I should see "<embeddingItemName>"
+    And I should see "<embeddedItemName>"
+    And response headers contain
+      | Header          | Value                  |
+      | Cache-Control   | public, s-maxage=86400 |
+    And response headers match pattern
+      | Header          | Pattern            |
+      | X-Symfony-Cache | <expectedPattern>  |
+
+    Examples:
+      | embeddingItemName  | embeddedItemName  | expectedPattern |
+      | EmbeddingItemNoEsi | EmbeddedItemNoEsi | /GET \/site\/embeddingitemnoesi\: fresh/ |
+      | EmbeddingItemEsi   | EmbeddedItemEsi   | /GET \/site\/embeddingitemesi\: fresh; GET \/_fragment\?_hash\=.*%3D&_path\=contentId%3D53%26viewType%3Dline%26_format%3Dhtml%26_locale%3Den_GB%26_controller%3Dez_content%253A%253AviewAction\: fresh/ |

--- a/features/symfony/permissions.feature
+++ b/features/symfony/permissions.feature
@@ -1,0 +1,40 @@
+@symfonycache
+Feature: Cached response is different for users with different permissions
+
+  @admin
+  Scenario: Content Items are cached based on users permissions
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I visit "Users/Administrator-users/Administrator-User" on siteaccess "site"
+    And I reload the page
+    And I should see "Administrator User"
+    And response headers contain
+      | Header          | Value                                                         |
+      | Cache-Control   | public, s-maxage=86400                                        |
+      | X-Symfony-Cache | GET /site/Users/Administrator-users/Administrator-User: fresh |
+    When I am viewing the pages on siteaccess "site" as "Anonymous"
+    And I visit "Users/Administrator-users/Administrator-User" on siteaccess "site"
+    Then I should not see "Administrator User"
+    And the url should match "login"
+
+  @admin
+  Scenario: Embedded Content Items are cached based on users permissions
+    Given I create a "testContentType" Content Type in "Content" with "testContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	     | yes      | yes	       | yes          |
+      | Content relation (single) | Relation  | relation   | yes      | no	       | yes          |
+    And I create "testContentType" Content items in root in "eng-GB"
+      | name            | relation                                      |
+      | TestContentItem | /Users/Administrator-users/Administrator-User |
+    And I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I visit "TestContentItem" on siteaccess "site"
+    And I reload the page
+    And I should see "TestContentItem"
+    And I should see "Administrator User"
+    And response headers contain
+      | Header          | Value                            |
+      | Cache-Control   | public, s-maxage=86400           |
+      | X-Symfony-Cache | GET /site/testcontentitem: fresh |
+    When I am viewing the pages on siteaccess "site" as "Anonymous"
+    And I visit "TestContentItem" on siteaccess "site"
+    Then I should see "TestContentItem"
+    And I should not see "Administrator User"

--- a/features/varnish/cache.feature
+++ b/features/varnish/cache.feature
@@ -6,7 +6,7 @@ Feature: As an site administrator I want my pages to be cached using Varnish
         Given I create "Folder" Content items in root in "eng-GB"
             | name       | short_name |
             | TestFolder | <itemName> |
-        And I am viewing the pages on siteaccess "site" as "<user>"
+        And I am viewing the pages on siteaccess "site" as "<user>" "<password>"
         When I visit <itemName> on siteaccess "site"
         And response headers contain
             | Header  | Value |

--- a/features/varnish/embed.feature
+++ b/features/varnish/embed.feature
@@ -1,0 +1,62 @@
+@varnish
+Feature: Caching of embedded items
+
+  @admin
+  Scenario Outline: Editing an embedded item refreshes the embedding item as well
+    Given I create a "embeddedContentType" Content Type in "Content" with "embeddedContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+    And I create "embeddedContentType" Content items in root in "eng-GB"
+      | name               |
+      | <embeddedItemName> |
+    And I create a "embeddingContentType" Content Type in "Content" with "embeddingContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	   | yes      | yes	       | yes          |
+      | Content relation (single) | Relation  | relation   | yes      | no	       | yes          |
+    And I create "embeddingContentType" Content items in root in "eng-GB"
+      | name                | relation            |
+      | <embeddingItemName> | /<embeddedItemName> |
+    And I am viewing the pages on siteaccess "site" as "<user>" with password "<password>"
+    And I visit "/<embeddingItemName>" on siteaccess "site"
+    And I reload the page
+    And I should see "<embeddingItemName>"
+    And I should see "<embeddedItemName>"
+    And response headers contain
+      | Header  | Value |
+      | X-Cache | HIT   |
+    When I edit "<embeddedItemName>" Content item in "eng-GB"
+      | name                     |
+      | <editedEmbeddedItemName> |
+    And I reload the page
+    # Give Varnish time to fetch the backend response
+    And I wait 5 seconds
+    # Second reload is needed because of soft purging
+    And I reload the page
+    Then I should see "<embeddingItemName>"
+    And I should see "<editedEmbeddedItemName>"
+
+    Examples:
+      | user      | password | embeddingItemName  | embeddedItemName  | editedEmbeddedItemName  |
+      | admin     | publish  | EmbeddingItemAdmin | AdminEmbeddedItem | EditedEmbeddedItemAdmin |
+      | anonymous |          | EmbeddingItemAnon  | AnonEmbeddedItem  | EditedEmbeddedItemAnon  |
+
+  Scenario Outline: Embedded requests are cached
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I start measuring time
+    And I visit "/<embeddingItemName>" on siteaccess "site"
+    And the action took longer than 5 seconds
+    And I should see "<embeddingItemName>"
+    And I should see "<embeddedItemName>"
+    When I start measuring time
+    And I reload the page
+    Then the action took no longer than 1 seconds
+    And I should see "<embeddingItemName>"
+    And I should see "<embeddedItemName>"
+    And response headers contain
+      | Header  | Value |
+      | X-Cache | HIT   |
+
+    Examples:
+      | embeddingItemName  | embeddedItemName  |
+      | EmbeddingItemNoEsi | EmbeddedItemNoEsi |
+      | EmbeddingItemEsi   | EmbeddedItemEsi   |

--- a/features/varnish/permissions.feature
+++ b/features/varnish/permissions.feature
@@ -1,0 +1,37 @@
+@varnish
+Feature: Cached response is different for users with different permissions
+
+  Scenario: Content Items are cached based on users permissions when directly visited
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I visit "Users/Administrator-users/Administrator-User" on siteaccess "site"
+    And I reload the page
+    And I should see "Administrator User"
+    And response headers contain
+      | Header  | Value |
+      | X-Cache | HIT   |
+    When I am viewing the pages on siteaccess "site" as "Anonymous"
+    And I visit "Users/Administrator-users/Administrator-User" on siteaccess "site"
+    Then I should not see "Administrator User"
+    And the url should match "login"
+
+  @admin
+  Scenario: Embedded Content Items are cached based on users permissions
+    Given I create a "testContentType" Content Type in "Content" with "testContentType" identifier
+      | Field Type                | Name      | Identifier | Required | Searchable | Translatable |
+      | Text line                 | Name      | name	     | yes      | yes	       | yes          |
+      | Content relation (single) | Relation  | relation   | yes      | no	       | yes          |
+    And I create "testContentType" Content items in root in "eng-GB"
+      | name            | relation                                       |
+      | TestContentItem | /Users/Administrator-users/Administrator-User |
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I visit "TestContentItem" on siteaccess "site"
+    And I reload the page
+    And I should see "TestContentItem"
+    And I should see "Administrator User"
+    And response headers contain
+      | Header  | Value |
+      | X-Cache | HIT   |
+    When I am viewing the pages on siteaccess "site" as "Anonymous"
+    And I visit "TestContentItem" on siteaccess "site"
+    Then I should see "TestContentItem"
+    And I should not see "Administrator User"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-116
| **Type**           | tests
| **Target version** | 2.3 (Product: 3.3)
| **BC breaks**      | no
| **Doc needed**     | no

Requires:
https://github.com/ezsystems/BehatBundle/pull/182

Added following Scenarios for both Symfony Proxy and Varnish:
1) Permissions: even when a page is cached for Admin the content for Anonymous is correct
2) Embeds: editing an embedded Content Item refreshes the cache for embedding Content item.
3) Embeds: subrequests are cached as well (standard and ESI)

**Before merge:**
Remove TMP commits

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
