### PR TITLE
Added information in regards to DFS and static files

### DIFF
--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -59,7 +59,8 @@ sub vcl_recv {
         }
     }
 
-    // Do a standard lookup on assets (these don't vary by user context hash)
+    // Do a standard lookup on assets (these don't vary by user context hash) unless assets are served by DFS.
+    // If you use DFS in your project, please remember to remove or comment out this section.
     // Note that file extension list below is not extensive, so consider completing it to fit your needs.
     if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
         return (hash);

--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -59,8 +59,8 @@ sub vcl_recv {
         }
     }
 
-    // Do a standard lookup on assets (these don't vary by user context hash) unless assets are served by DFS.
-    // If you use DFS in your project, please remember to remove or comment out this section.
+    // Do a standard lookup on assets (these don't vary by user context hash).
+    // If you use DFS in your project, please remember to remove from the list those extensions, which are served using DFS.
     // Note that file extension list below is not extensive, so consider completing it to fit your needs.
     if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
         return (hash);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Type**           | Improvement
| **Target version** | `1.0`
| **BC breaks**      | no
| **Doc needed**     | yes

If the project is set to use DFS to serve static files, the Response's `Vary` header will always be set to `Cookie, Authorization` due to the missing `X-User-Hash` header inside Request coming from Varnish.