### PR TITLE
IBX-665: Changed how the Symfony Reverse proxy is enabled

### DIFF
--- a/tests/SymfonyProxy/enable_symfony_proxy.patch
+++ b/tests/SymfonyProxy/enable_symfony_proxy.patch
@@ -1,33 +1,32 @@
-From 25a9974e189564d3bcc20a1477c4962d7ffa24bc Mon Sep 17 00:00:00 2001
+From fe9ff7bd801f978cfc50aae0411bb3eefdd3059a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marek=20Noco=C5=84?= <mnocon@users.noreply.github.com>
-Date: Fri, 19 Feb 2021 17:58:14 +0100
-Subject: [PATCH] Added cache kernel
+Date: Wed, 7 Jul 2021 15:29:57 +0200
+Subject: [PATCH] Enabled Symfony Reverse Proxy
 
 ---
- public/index.php | 3 +++
- 1 file changed, 3 insertions(+)
+ public/index.php | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/public/index.php b/public/index.php
-index 3bcee0b..f97d416 100644
+index 9982c21..03ac40a 100644
 --- a/public/index.php
 +++ b/public/index.php
-@@ -1,6 +1,7 @@
+@@ -1,9 +1,14 @@
  <?php
  
  use App\Kernel;
 +use EzSystems\PlatformHttpCacheBundle\AppCache;
- use Symfony\Component\Dotenv\Dotenv;
- use Symfony\Component\ErrorHandler\Debug;
- use Symfony\Component\HttpFoundation\Request;
-@@ -16,6 +17,8 @@ if ($_SERVER['APP_DEBUG']) {
- }
++use Symfony\Component\HttpFoundation\Request;
  
- $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
-+$kernel = new AppCache($kernel);
-+Request::enableHttpMethodParameterOverride();
- $request = Request::createFromGlobals();
- $response = $kernel->handle($request);
- $response->send();
+ require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+ 
+ return function (array $context) {
+-    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
++    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
++    Request::enableHttpMethodParameterOverride();
++
++    return new AppCache($kernel);
+ };
 -- 
 2.30.0
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-665
| **Type**           | Misc
| **Target version** | 2.3/master
| **BC breaks**      | no
| **Doc needed**     | no

Symfony 5.3 comes with a new [Runtime component](https://symfony.com/doc/current/components/runtime.html), which changes how the `public/index.php` file looks. This makes the current way of enabling Symfony Proxy invalid, as the patch cannot be applied on the new file and needs to be adapted.

We still need to do three things:
1) Use our own `AppCache` class, as described in https://doc.ibexa.co/en/latest/guide/http_cache/#symfony-reverse-proxy
2) Wrap the Kernel with it: https://symfony.com/doc/current/http_cache.html#symfony-reverse-proxy
3) Call `Request::enableHttpMethodParameterOverride` method (https://symfony.com/doc/current/reference/configuration/framework.html#http-method-override)

Before applying the patch:
```
<?php
// public/index.php
use App\Kernel;

require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

return function (array $context) {
    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
};
```

And after the patch:
```
<?php

use App\Kernel;
use EzSystems\PlatformHttpCacheBundle\AppCache;
use Symfony\Component\HttpFoundation\Request;

require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

return function (array $context) {
    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
    Request::enableHttpMethodParameterOverride();

    return new AppCache($kernel);
};
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
