### PR TITLE
Fix a recursive find of directory argument being itself recursively browsed

### DIFF
--- a/src/Proxy/TagAwareStore.php
+++ b/src/Proxy/TagAwareStore.php
@@ -169,7 +169,7 @@ class TagAwareStore extends Store implements RequestAwarePurger
      */
     protected function purgeAllContent()
     {
-        $this->getFilesystem()->remove((new Finder())->in($this->root));
+        $this->getFilesystem()->remove((new Finder())->in($this->root)->depth(0));
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Type**           | Bug
| **Target version** | 1.0
| **BC breaks**      | no
| **Doc needed**     | no

Hi !
On several of our "eZPlatform 2.5 + Legacy bridge" apps, with a purge_type "local" (no varnish / http), we sometimes stumbled on a 512Mo memory_limit reached when the cache is "old enough" (read "having lots of files") and the site owner edited some content in legacy back office. The error was always triggered on vendor/symfony/symfony/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php:81

This PR fix the memory problem, which can be replaced by a "Maximum execution time of 30 seconds exceeded" (which will be harder to fix as it's only the time needed by the filesystem to remove its files).

Regards,
Marc

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
