### PR TITLE
Move to GitHub actions

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -1,0 +1,44 @@
+name: Browser tests
+
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+'
+    pull_request: ~
+
+jobs:
+    symfony-cache:
+        name: "Symfony Cache integration tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: 'oss'
+            project-version: '^3.3.x-dev'
+            test-suite: '--mode=standard --profile=httpCache --suite=symfonycache'
+            test-setup-phase-1:  '--mode=standard --profile=httpCache --suite=setup-symfony-cache'
+            test-setup-phase-2: '--mode=standard --profile=httpCache --suite=setup'
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    varnish:
+        name: "Varnish integration tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: 'oss'
+            project-version: '^3.3.x-dev'
+            setup: "doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
+            test-suite:  '--mode=standard --profile=httpCache --suite=varnish'
+            test-setup-phase-1: '--mode=standard --profile=httpCache --suite=setup'
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    varnish-token:
+        name: "Varnish integration tests with invalidate token"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: 'oss'
+            project-version: '^3.3.x-dev'
+            setup: "doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
+            test-suite:  '--mode=standard --profile=httpCache --suite=varnish'
+            test-setup-phase-1: '--mode=standard --profile=httpCache --suite=setup-token'
+            test-setup-phase-2: '--mode=standard --profile=httpCache --suite=setup'
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,31 +26,6 @@ matrix:
             - USER_RUNNING_TESTS=root
             - PHP_IMAGE=ezsystems/php:7.3-v1
             - WEB_HOST=web
-        - name: "PHP 7.3 Symfony Cache integration tests"
-          php: 7.3
-          env:
-            - TEST_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=symfonycache -c=behat_ibexa_oss.yaml"
-            - SETUP_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=setup -c=behat_ibexa_oss.yaml"
-            - WEB_HOST="http://web"
-            - APP_DEBUG=1
-            - ENABLE_SYMFONY_CACHE=1
-        - name: "PHP 7.3 Varnish integration tests"
-          php: 7.3
-          env:
-            - TEST_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=varnish -c=behat_ibexa_oss.yaml"
-            - SETUP_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=setup -c=behat_ibexa_oss.yaml"
-            - APP_DEBUG=1
-            - WEB_HOST="http://varnish"
-            - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
-        - name: "PHP 7.3 Varnish integration tests with invalidate token"
-          php: 7.3
-          env:
-            - TEST_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=varnish -c=behat_ibexa_oss.yaml"
-            - SETUP_CMD="vendor/bin/ezbehat --mode=standard --profile=httpCache --suite=setup -c=behat_ibexa_oss.yaml"
-            - HTTPCACHE_VARNISH_INVALIDATE_TOKEN=TESTTOKEN
-            - APP_DEBUG=1
-            - WEB_HOST="http://varnish"
-            - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
 
 # test only master + stable (+ Pull requests)
 branches:
@@ -63,15 +38,10 @@ before_script:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - travis_retry composer install --prefer-dist --no-interaction
     - ./vendor/bin/prepare_project_edition.sh oss ${PROJECT_VERSION} ${COMPOSE_FILE}
-    # Execute Symfony command if injected into test matrix
-    - if [ "${SYMFONY_CMD}" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user www-data app sh -c "APP_ENV=behat php bin/console ${SYMFONY_CMD}" ; fi
-    - if [ "${ENABLE_SYMFONY_CACHE}" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user www-data app sh -c "patch -p1 -i vendor/ezsystems/ezplatform-http-cache/tests/SymfonyProxy/enable_symfony_proxy.patch" ; fi
-    - if [ "$SETUP_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "$SETUP_CMD"  ; fi
-    - if [ "$SETUP_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "composer run post-install-cmd"  ; fi
+    - cd "$HOME/build/project"; docker-compose exec --user www-data app sh -c "APP_ENV=behat php bin/console ${SYMFONY_CMD}"
 
 script:
-    - if [ "$REST_TEST" != "" ] ; then cd "$HOME/build/project"; docker-compose exec app sh -c "cd vendor/ezsystems/ezplatform-rest && composer update --no-interaction && php ./vendor/bin/phpunit -c phpunit-integration-rest.xml" ; fi
-    - if [ "$TEST_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "$TEST_CMD"  ; fi
+    - cd "$HOME/build/project"; docker-compose exec app sh -c "cd vendor/ezsystems/ezplatform-rest && composer update --no-interaction && php ./vendor/bin/phpunit -c phpunit-integration-rest.xml"
 
 notifications:
   slack:

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -32,9 +32,19 @@ httpCache:
                 - Ibexa\Behat\Browser\Context\ContentPreviewContext
         setup:
             paths:
-                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup'
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup/setup.feature'
             contexts:
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
                 - EzSystems\Behat\Core\Context\ConfigurationContext
                 - EzSystems\Behat\API\Context\ContentContext
+        setup-token:
+            paths:
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup/invalidateToken.feature'
+            contexts:
+                - EzSystems\Behat\Core\Context\ConfigurationContext
+        setup-symfony-cache:
+            paths:
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup/symfonyCache.feature'
+            contexts:
+                - EzSystems\Behat\Core\Context\FileContext

--- a/features/setup/invalidateToken.feature
+++ b/features/setup/invalidateToken.feature
@@ -1,0 +1,8 @@
+@setup
+Feature: Set system to use token for invalidation
+
+  Scenario: Set up the system to test caching of subrequests
+    Given I append configuration to "parameters"
+    """
+        varnish_invalidate_token: 'TESTTOKEN'
+    """

--- a/features/setup/symfonyCache.feature
+++ b/features/setup/symfonyCache.feature
@@ -1,3 +1,9 @@
+@setup
+Feature: Set up the system to use Symfony Proxy
+
+  Scenario: Set up the system to use Symfony Proxy
+    Given I apply the patch
+"""
 From fe9ff7bd801f978cfc50aae0411bb3eefdd3059a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marek=20Noco=C5=84?= <mnocon@users.noreply.github.com>
 Date: Wed, 7 Jul 2021 15:29:57 +0200
@@ -29,4 +35,4 @@ index 9982c21..03ac40a 100644
  };
 -- 
 2.30.0
-
+"""


### PR DESCRIPTION
Requires: https://github.com/ezsystems/BehatBundle/pull/245

Migrated most jobs to Github Actions - REST tests are left as is, they will be moved another time.

Because the HTTP cache tests required unusual setup (enabling Symfony Proxy by applying a patch or specifying the Varnish token with an env variable) I had to adjust things:
1) The token for invalidation is set by directly setting the `varnish_invalidate_token` parameter
2) The patch is applied using a step, in the setup phase

