### PR TITLE
IBX-1784: Introduced translation-aware HTTP cache invalidation on content publication

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -30,6 +30,18 @@ jobs:
             test-setup-phase-1: '--mode=standard --profile=httpCache --suite=setup'
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    varnish-translation-aware:
+        name: "Varnish integration tests (translation-aware)"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: 'oss'
+            project-version: '^3.3.x-dev'
+            setup: "doc/docker/base-dev.yml:doc/docker/varnish.yml:doc/docker/selenium.yml"
+            test-suite:  '--mode=standard --profile=httpCache --suite=varnish-translation-aware'
+            test-setup-phase-1: '--mode=standard --profile=httpCache --suite=setup-translation-aware'
+            test-setup-phase-2: '--mode=standard --profile=httpCache --suite=setup'
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     varnish-token:
         name: "Varnish integration tests with invalidate token"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -19,7 +19,22 @@ httpCache:
             paths:
                 - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/varnish'
             filters:
-                tags: '@varnish' 
+                tags: '@varnish&&~@translationAware' 
+            contexts:
+                - EzSystems\Behat\API\Context\TestContext
+                - EzSystems\Behat\API\Context\ContentTypeContext
+                - EzSystems\Behat\Core\Context\TimeContext
+                - EzSystems\Behat\Core\Context\ConfigurationContext
+                - EzSystems\Behat\API\Context\ContentContext
+                - Ibexa\Behat\Browser\Context\BrowserContext
+                - Ibexa\Behat\Browser\Context\AuthenticationContext
+                - Behat\MinkExtension\Context\MinkContext
+                - Ibexa\Behat\Browser\Context\ContentPreviewContext
+        varnish-translation-aware:
+            paths:
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/varnish'
+            filters:
+                tags: '@varnish&&~@translationNotAware' 
             contexts:
                 - EzSystems\Behat\API\Context\TestContext
                 - EzSystems\Behat\API\Context\ContentTypeContext
@@ -38,6 +53,7 @@ httpCache:
                 - EzSystems\Behat\API\Context\ContentTypeContext
                 - EzSystems\Behat\Core\Context\ConfigurationContext
                 - EzSystems\Behat\API\Context\ContentContext
+                - EzSystems\Behat\API\Context\LanguageContext
         setup-token:
             paths:
                 - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup/invalidateToken.feature'
@@ -48,3 +64,8 @@ httpCache:
                 - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup/symfonyCache.feature'
             contexts:
                 - EzSystems\Behat\Core\Context\FileContext
+        setup-translation-aware:
+            paths:
+                - '%paths.base%/vendor/ezsystems/ezplatform-http-cache/features/setup/translationAware.feature'
+            contexts:
+                - EzSystems\Behat\Core\Context\ConfigurationContext

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "autoload": {
         "psr-4": {
             "EzSystems\\PlatformHttpCacheBundle\\": "src",
-            "EzSystems\\PlatformHttpCacheBundle\\Tests\\": "tests"
+            "EzSystems\\PlatformHttpCacheBundle\\Tests\\": "tests",
+            "Ibexa\\HttpCache\\": "src"
         }
     },
     "scripts": {

--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -131,6 +131,11 @@ sub vcl_backend_response {
     ) {
         set beresp.do_gzip = true;
     }
+
+    // Modify xkey header to add translation suffix
+    if (beresp.http.xkey && beresp.http.x-lang) {
+        set beresp.http.xkey = beresp.http.xkey + " " + regsuball(beresp.http.xkey, "(\S+)", "\1" + beresp.http.x-lang);
+    }
 }
 
 // Handle purge
@@ -323,6 +328,7 @@ sub vcl_deliver {
     } else {
         // Remove tag headers when delivering to non debug client
         unset resp.http.xkey;
+        unset resp.http.x-lang;
         // Sanity check to prevent ever exposing the hash to a non debug client.
         unset resp.http.x-user-context-hash;
     }

--- a/features/setup/setup.feature
+++ b/features/setup/setup.feature
@@ -1,7 +1,18 @@
 @setup
 Feature: Set system to desired state before tests
   
-  @admin
+  @APIUser:admin
+  Scenario: Set up the system to test translations
+    Given Language "Polish" with code "pol-PL" exists
+    And Language "French" with code "fre-FR" exists
+    And I set configuration to "admin_group" siteaccess
+      | key                          | value                |
+      | languages                    | eng-GB,pol-PL,fre-FR |
+    And I set configuration to "site" siteaccess
+      | key                          | value                |
+      | languages                    | eng-GB,pol-PL,fre-FR |
+
+  @APIUser:admin
   Scenario: Set up the system to test caching of subrequests
     Given I create a "embeddedContentType" Content Type in "Content" with "embeddedContentType" identifier
       | Field Type                | Name      | Identifier | Required | Searchable | Translatable |

--- a/features/setup/symfonyCache.feature
+++ b/features/setup/symfonyCache.feature
@@ -1,4 +1,4 @@
-@setup
+@setup @symfonyCache
 Feature: Set up the system to use Symfony Proxy
 
   Scenario: Set up the system to use Symfony Proxy

--- a/features/setup/translationAware.feature
+++ b/features/setup/translationAware.feature
@@ -1,0 +1,8 @@
+@setup @translationAware
+Feature: Set system to use translation-aware cache invalidation
+
+  Scenario: Set up the system to use translation-aware cache invalidation
+    Given I append configuration to "parameters"
+    """
+        ibexa.http_cache.translation_aware.enabled: true
+    """

--- a/features/varnish/translations.feature
+++ b/features/varnish/translations.feature
@@ -1,0 +1,101 @@
+@varnish
+Feature: As an site administrator I want my pages to be cached using Varnish
+
+    @APIUser:admin
+    Scenario Outline: Correct translation is displayed when a new translation is published
+        Given I create "Folder" Content items in root in "pol-PL"
+            | name       | short_name |
+            | TestFolder | <itemName> |
+        And I am viewing the pages on siteaccess "site" as "<user>" "<password>"
+        And I visit "<itemName>" on siteaccess "site"
+        And I reload the page
+        And I see correct preview data for "Folder" Content Type
+            | field | value      |
+            | title | <itemName> |
+        And response headers contain
+            | Header  | Value |
+            | X-Cache | HIT   |
+        When I edit "<itemName>" Content item in "eng-GB"
+            | short_name          |
+            | <itemNameAfterEdit> |
+        And I reload the page
+        # Give Varnish time to fetch the backend response
+        And I wait 5 seconds
+        # Second reload is needed because of soft purging
+        And I reload the page
+        And I reload the page
+        Then I see correct preview data for "Folder" Content Type
+            | field | value               |
+            | title | <itemNameAfterEdit> |
+        And response headers contain
+            | Header  | Value |
+            | X-Cache | HIT   |
+
+        Examples:
+            | user      | password | itemName        | itemNameAfterEdit |
+            | admin     | publish  | ItemPolskiAdmin | ItemEnglishAdmin  |
+            | anonymous |          | ItemPolskiAnon  | ItemEnglishAnon   |
+
+  @APIUser:admin @javascript @translationNotAware
+  Scenario: Main translation cache is purged when a fallback translation is edited
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I create "embeddedContentType" Content items in root in "eng-GB"
+        | name                       |
+        | EmbeddedTranslationEnglish |
+    And I create "embeddingContentType_no_esi" Content items in root in "eng-GB"
+        | name                        | relation                    |
+        | EmbeddingTranslationEnglish | /EmbeddedTranslationEnglish |
+    And I edit "EmbeddedTranslationEnglish" Content item in "fre-FR"
+        | name                      |
+        | EmbeddedTranslationFrench |
+    And I start measuring time
+    And I visit "/EmbeddingTranslationEnglish" on siteaccess "site"
+    And the action took longer than 5 seconds
+    And I should see "EmbeddingTranslationEnglish"
+    And I should see "EmbeddedTranslationEnglish"
+    And I start measuring time
+    And I reload the page
+    And the action took no longer than 1 seconds
+    When I edit "EmbeddedTranslationEnglish" Content item in "fre-FR"
+        | name                            |
+        | EmbeddedTranslationFrenchEdited |
+    # Give Varnish time to get purged
+    And I wait 1 seconds
+    And I start measuring time
+    And I reload the page
+    And I reload the page
+    Then I should see "EmbeddingTranslationEnglish"
+    And I should see "EmbeddedTranslationEnglish"
+    And the action took longer than 5 seconds
+
+  @APIUser:admin @javascript @translationAware
+  Scenario: Main translation cache is not purged when a fallback translation is edited
+    Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
+    And I create "embeddedContentType" Content items in root in "eng-GB"
+        | name                       |
+        | EmbeddedTranslationEnglish |
+    And I create "embeddingContentType_no_esi" Content items in root in "eng-GB"
+        | name                        | relation                    |
+        | EmbeddingTranslationEnglish | /EmbeddedTranslationEnglish |
+    And I edit "EmbeddedTranslationEnglish" Content item in "fre-FR"
+        | name                      |
+        | EmbeddedTranslationFrench |
+    And I start measuring time
+    And I visit "/EmbeddingTranslationEnglish" on siteaccess "site"
+    And the action took longer than 5 seconds
+    And I should see "EmbeddingTranslationEnglish"
+    And I should see "EmbeddedTranslationEnglish"
+    And I start measuring time
+    And I reload the page
+    And the action took no longer than 1 seconds
+    When I edit "EmbeddedTranslationEnglish" Content item in "fre-FR"
+        | name                            |
+        | EmbeddedTranslationFrenchEdited |
+    # Give Varnish time to get purged
+    And I wait 1 seconds
+    And I start measuring time
+    And I reload the page
+    And I reload the page
+    Then I should see "EmbeddingTranslationEnglish"
+    And I should see "EmbeddedTranslationEnglish"
+    And the action took no longer than 1 seconds

--- a/src/EventSubscriber/AddContentLanguageHeaderSubscriber.php
+++ b/src/EventSubscriber/AddContentLanguageHeaderSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\HttpCache\EventSubscriber;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class AddContentLanguageHeaderSubscriber implements EventSubscriberInterface
+{
+    public const CONTENT_LANGUAGE_HEADER = 'x-lang';
+
+    /** @var bool */
+    private $isTranslationAware;
+
+    public function __construct(bool $isTranslationAware)
+    {
+        $this->isTranslationAware = $isTranslationAware;
+    }
+
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        if (!$this->isTranslationAware || HttpKernelInterface::MASTER_REQUEST != $event->getRequestType()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $view = $request->attributes->get('view');
+        if (!$view instanceof CachableView || !$view->isCacheEnabled()) {
+            return;
+        }
+
+        $content = $request->attributes->get('content');
+        if ($content instanceof Content) {
+            $event->getResponse()->headers->add([self::CONTENT_LANGUAGE_HEADER => $content->getDefaultLanguageCode()]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+}

--- a/src/Handler/ContentTagInterface.php
+++ b/src/Handler/ContentTagInterface.php
@@ -12,6 +12,7 @@ namespace EzSystems\PlatformHttpCacheBundle\Handler;
 interface ContentTagInterface
 {
     public const CONTENT_PREFIX = 'c';
+    public const CONTENT_ALL_TRANSLATIONS_PREFIX = 'ca';
     public const LOCATION_PREFIX = 'l';
     public const PARENT_LOCATION_PREFIX = 'pl';
     public const PATH_PREFIX = 'p';

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -2,3 +2,5 @@ parameters:
     ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ezplatform.http_cache.invalidate_token.ttl: 86400
     ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
+    ibexa.http_cache.translation_aware.enabled.default_value: false
+    ibexa.http_cache.translation_aware.enabled: "%env(default:ibexa.http_cache.translation_aware.enabled.default_value:bool:HTTPCACHE_TRANSLATION_AWARE_ENABLED)%"

--- a/src/Resources/config/event.yml
+++ b/src/Resources/config/event.yml
@@ -4,8 +4,17 @@ services:
         autowire: true
         public: false
 
+    EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\ContentEventsSubscriber:
+        arguments:
+            $purgeClient: '@ezplatform.http_cache.purge_client'
+            $locationHandler: '@ezpublish.spi.persistence.cache.locationHandler'
+            $urlHandler: '@ezpublish.spi.persistence.cache.urlHandler'
+            $contentHandler: '@ezpublish.spi.persistence.cache.contentHandler'
+            $isTranslationAware: '%ibexa.http_cache.translation_aware.enabled%'
+
     EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\:
         resource: '../../EventSubscriber/CachePurge/*'
+        exclude: '../../EventSubscriber/CachePurge/ContentEventsSubscriber.php'
         arguments:
             $purgeClient: '@ezplatform.http_cache.purge_client'
             $locationHandler: '@ezpublish.spi.persistence.cache.locationHandler'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -92,6 +92,12 @@ services:
         tags:
             - { name: kernel.event_subscriber, priority: -100 }
 
+    Ibexa\HttpCache\EventSubscriber\AddContentLanguageHeaderSubscriber:
+        arguments:
+            - '%ibexa.http_cache.translation_aware.enabled%'
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezplatform.http_cache.repository_tag_prefix:
         class: EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix
         # Use config resolver to be able to lazy load reading SA setting "repository" to avoid scope change issues


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-1784](https://issues.ibexa.co/browse/IBX-1784)
| **Type**           | Improvement
| **Target version** | `2.3`
| **BC breaks**      | no
| **Doc needed**     | yes

Requires: https://github.com/ezsystems/ezplatform-kernel/pull/279
Fastly changes: https://github.com/ezsystems/ezplatform-http-cache-fastly/pull/35
Recipes: https://github.com/ibexa/recipes/pull/72

This PR introduces changes to HTTP Cache purging on a version published which improves performance by allowing to purge only HTTP Cache relevant for translation's language. Currently, when any translation is published, all HTTP cache related to the content is purged, causing for the HTTP cache not affected by the content change to be rebuilt unnecessarily.

This PR introduces some changes in VCL, tagging, and purging.

**Tagging:**
Before sending the content's response, a new `xlang` header containing the translation's language code is added. When `prioritizedFieldLanguageCode` is `null` it means that the Content requested is a fallback for missing translation, therefore  `initialLanguageCode` is used to avoid purging issues.

In VCL, `xkey` header is duplicated, modified by adding `xlang` value as a suffix to the duplicated tags, and used to tag response with original `xkey`. Additional tags have to be introduced for proper invalidation but to avoid issues with the webserver's maximum header size, they are synthesized inside VCL.

**Purging:**
When a new version is published, all tags are tagged with a translation's Language Code suffix and invalidated (we don't have to worry about maximum header size here, as the request is chunked by `ProxyClient`). 
This occurs when the translation is not the main translation or when the content's Content Type does not have non-translatable fields.

If those conditions are not met, HTTP cache is purged without language code suffix, invalidating all content-related HTTP cache.

**Potential problems:**
I've planed to add `xlang` header to the purge requests as well - which would be a more elegant way to handle tags with language code suffix inside VCL (there is no risk of cache purging issues when someone upgrades packages version, but won't modify the VCL). Unfortunately, I wasn't able to find a way to do that without ugly hacking. Maybe someone has an idea how/if it can be done?


**TODO**:
- [x] Add changes to Fastly's vcl
- [x] Add tag for clearing all translations from template
- [x] Invalidate AA content when translation is created 
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.