### PR TITLE
[CI] Run Composer commands in non-interactive mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
     - if [ "$SETUP_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "composer run post-install-cmd"  ; fi
 
 script:
-    - if [ "$REST_TEST" != "" ] ; then cd "$HOME/build/project"; docker-compose exec app sh -c "cd vendor/ezsystems/ezplatform-rest && composer update && php ./vendor/bin/phpunit -c phpunit-integration-rest.xml" ; fi
+    - if [ "$REST_TEST" != "" ] ; then cd "$HOME/build/project"; docker-compose exec app sh -c "cd vendor/ezsystems/ezplatform-rest && composer update --no-interaction && php ./vendor/bin/phpunit -c phpunit-integration-rest.xml" ; fi
     - if [ "$TEST_CMD" != "" ] ; then cd "$HOME/build/project"; docker-compose exec --user "$USER_RUNNING_TESTS" app sh -c "$TEST_CMD"  ; fi
 
 notifications:


### PR DESCRIPTION
Failing build: https://app.travis-ci.com/github/ezsystems/ezplatform-http-cache/jobs/555162385

Noninteractive mode prevent us from triggering a prompt in CI runs:
```
~/Desktop/repos/ezplatform-http-cache on 2.3 ?2 ❯ composer update                                                                                                                                                ✘ INT took 15s at 08:41:57
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Package operations: 163 installs, 0 updates, 0 removals
  - Installing composer/package-versions-deprecated (1.11.99.4): Extracting archive
composer/package-versions-deprecated contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "composer/package-versions-deprecated" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```