### PR TITLE
Added UserContextListener return type for upstream compliance

### DIFF
--- a/src/Proxy/UserContextListener.php
+++ b/src/Proxy/UserContextListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class UserContextListener extends BaseUserContextListener
 {
-    protected function cleanupHashLookupRequest(Request $hashLookupRequest, Request $originalRequest)
+    protected function cleanupHashLookupRequest(Request $hashLookupRequest, Request $originalRequest): void
     {
         parent::cleanupHashLookupRequest($hashLookupRequest, $originalRequest);
         // Embed the original request as we need it to match the SiteAccess.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Type**           | Bugfix?
| **Target version** | 2.3 (v3.3) and main (v4)
| **BC breaks**      | ? Don't know if people can extend this class
| **Doc needed**     | depends on ☝️ 

FriendsOfSymfony/FOSHttpCache had a release yesterday: https://github.com/FriendsOfSymfony/FOSHttpCache/releases
which added some missing return types: https://github.com/FriendsOfSymfony/FOSHttpCache/commit/845d4eba3240acd92ac38c42ba752c8988b42fa2#diff-d62a82de1d7d34132a7fa5d435b2ecf0248b9858d059d001e7276f4d236c44bbL135-R135

Our tests started failing (https://app.travis-ci.com/github/ezsystems/ezplatform-http-cache/jobs/555413378)
with:
```
     | anonymous |          | TestFolderShortNameAnonymous | GET /site/testfoldershortnameanonymous: fresh |
        Failed asserting that expected string 'TestFolderShortNameAnonymous' is equal to actual 'FatalError' for css locator 'title': 'h2'
        Failed asserting that two strings are equal.
```

And trying to use Symfony Proxy in our application ends with:

![Zrzut ekranu 2022-01-13 o 10 50 27](https://user-images.githubusercontent.com/10993858/149306787-521c9196-1806-4edd-8e23-888211d054b3.png)
