### PR TITLE
IBX-3749: Fixed removal of Vary: cookie and authorization headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,11 @@
             "Ibexa\\HttpCache\\": "src"
         }
     },
+    "autoload-dev": {
+        "autoload-dev": {
+            "Ibexa\\Tests\\Bundle\\HttpCache\\": "tests/bundle/"
+        }
+    },
     "scripts": {
         "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
         "unit": "phpunit -c phpunit.xml",

--- a/tests/bundle/EventListener/ConditionallyRemoveVaryHeaderListenerTest.php
+++ b/tests/bundle/EventListener/ConditionallyRemoveVaryHeaderListenerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Bundle\HttpCache\EventListener;
+
+use EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class ConditionallyRemoveVaryHeaderListenerTest extends TestCase
+{
+    /** @var EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener */
+    public $conditionallyRemoveVaryHeaderListener;
+
+    protected function setUp(): void
+    {
+        $this->conditionallyRemoveVaryHeaderListener = new ConditionallyRemoveVaryHeaderListener(['testroute1', 'testroute2']);
+    }
+
+    /**
+     * @return iterable<array{varyHeaders: string[], expectedVaryHeaders: string[]}>
+     */
+    public function onKernelResponseProvider(): iterable
+    {
+        return [
+            [
+                'varyHeaders' => ['Cookie', 'vtest'],
+                'expectedVaryHeaders' => ['vtest'],
+            ],
+            [
+                'varyHeaders' => ['Authorization'],
+                'expectedVaryHeaders' => [],
+            ],
+            [
+                'varyHeaders' => ['cookie'],
+                'expectedVaryHeaders' => [],
+            ],
+            [
+                'varyHeaders' => ['authorization'],
+                'expectedVaryHeaders' => [],
+            ],
+            [
+                'varyHeaders' => ['Cookie', 'vtest'],
+                'expectedVaryHeaders' => ['vtest'],
+            ],
+            [
+                'varyHeaders' => ['vtest', 'Cookie'],
+                'expectedVaryHeaders' => ['vtest'],
+            ],
+            [
+                'varyHeaders' => ['cookie', 'vtest'],
+                'expectedVaryHeaders' => ['vtest'],
+            ],
+            [
+                'varyHeaders' => ['cookie', 'vtest', 'vtest2', 'vtest3', 'authorization'],
+                'expectedVaryHeaders' => ['vtest', 'vtest2', 'vtest3'],
+            ],
+            [
+                'varyHeaders' => ['cookie', 'vtest', 'vtest2', 'vtest3', 'authorization', 'vtest4'],
+                'expectedVaryHeaders' => ['vtest', 'vtest2', 'vtest3', 'vtest4'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider onKernelResponseProvider
+     *
+     * @param string[] $varyHeaders
+     * @param string[] $expectedVaryHeaders
+     */
+    public function testOnKernelResponse(array $varyHeaders, array $expectedVaryHeaders): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('get')
+            ->willReturn('testroute1');
+
+        $response = new Response('test content', 200, ['vary' => $varyHeaders]);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $this->conditionallyRemoveVaryHeaderListener->onKernelResponse($event);
+        self::assertNotContains('cookie', $response->headers->all('vary'));
+        self::assertNotContains('Cookie', $response->headers->all('vary'));
+        self::assertNotContains('authorization', $response->headers->all('vary'));
+        self::assertNotContains('Authorization', $response->headers->all('vary'));
+        foreach ($expectedVaryHeaders as $expectedVaryHeader) {
+            self::assertContains($expectedVaryHeader, $response->headers->all('vary'));
+        }
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-3749](https://jira.ez.no/browse/IBX-3749)
| **Type**           | Bug
| **Target version** | `2.3`
| **BC breaks**      | no
| **Doc needed**     |no

fyi : Template says Target version 0.8 for bug fixes, but I assume correct one is 2.3, right ?


The ConditionallyRemoveVaryHeaderListener is supposed to remove `cookie` and `authorization` responses from Vary header. You may configure responses from custom controllers to be cleaned up with this listener using 
```
parameters:
ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken', 'my_custom_route']
```

The previous code didn't work. A quick fix would be:
```diff
-unset($varyHeaders[array_search(strtolower($removableVary), [$varyHeaders])]);
+unset($varyHeaders[array_search(strtolower($removableVary), $varyHeaders)]);
```

However, that would not be sufficient because `array_search(strtolower($removableVary), $varyHeaders)` will return `false` if `$removableVary` is not found. And `unset($varyHeaders[false]` will remove first element in `$varyHeaders` and that is not intended.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
